### PR TITLE
Make PanelHeader implement HasWidgets because it allows child widgets

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/PanelHeader.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/PanelHeader.java
@@ -20,6 +20,7 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
+import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.base.mixin.TextMixin;
 import org.gwtbootstrap3.client.ui.constants.Styles;
@@ -27,7 +28,7 @@ import org.gwtbootstrap3.client.ui.constants.Styles;
 /**
  * @author Joshua Godi
  */
-public class PanelHeader extends Div implements HasId, HasText {
+public class PanelHeader extends Div implements HasId, HasWidgets, HasText {
     private final TextMixin<PanelHeader> textMixin = new TextMixin<PanelHeader>(this);
 
     public PanelHeader() {


### PR DESCRIPTION
This PR adds the HasWidgets interface to PanelHeader before HasText. Therefore we can start using GWT's HasText and not break the demo as [reported](https://github.com/gwtbootstrap3/gwtbootstrap3/commit/732171fef99b4c282e2ee60d6889ed35d5041731#comments).
