### PR TITLE
Use info class for highlighting selections fixes #181

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/gwt/CellTable.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/gwt/CellTable.java
@@ -276,12 +276,12 @@ public class CellTable<T> extends com.google.gwt.user.cellview.client.CellTable<
 
         @Override
         public String cellTableHoveredRow() {
-            return DUMMY; // Note: Setting 'active' on the row disables 'bg-primary' :/
+            return "active";
         }
 
         @Override
         public String cellTableHoveredRowCell() {
-            return DUMMY; // Note: Setting 'active' on the cell disables 'bg-primary' :/
+            return "active";
         }
 
         @Override
@@ -331,7 +331,7 @@ public class CellTable<T> extends com.google.gwt.user.cellview.client.CellTable<
 
         @Override
         public String cellTableSelectedRow() {
-            return "bg-primary"; // Bootstrap3 helper class
+            return "info";
         }
 
         @Override


### PR DESCRIPTION
"bg-primary" does not work with striped tables.
By using contextual class info table hovering ("active" class) can also be used.
