### PR TITLE
#152: Ensure at least one ColumnSize must be set

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Column.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Column.java
@@ -71,7 +71,6 @@ public class Column extends Div {
      */
     public Column(final ColumnSize firstSize, final ColumnSize... otherSizes) {
         setSize(firstSize, otherSizes);
-        setStyleName(firstSize.getCssName());
     }
 
     /**


### PR DESCRIPTION
Ensures at least one ColumnSize must be set, both during construction and with setters. Had to remove constructor with the Widget varargs constructor as the signature would be identical to the ColumnSize varargs constructor. Widgets can still be added after construction using the add method.
