### PR TITLE
Alert is now properly detached from parent when closed

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Alert.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Alert.java
@@ -180,6 +180,7 @@ public class Alert extends Div implements HasWidgets, HasText, HasType<AlertType
      * @param evt event
      */
     protected void onClosed(final Event evt) {
+        removeFromParent();
         fireEvent(new AlertClosedEvent(evt));
     }
 


### PR DESCRIPTION
Fixes gwtbootstrap3/gwtbootstrap3#192
