### PR TITLE
Fix selection highlighting on DataGrid

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/gwt/DataGrid.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/gwt/DataGrid.java
@@ -62,6 +62,7 @@ public class DataGrid<T> extends com.google.gwt.user.cellview.client.DataGrid<T>
      */
     public DataGrid(final int pageSize, final ProvidesKey<T> keyProvider) {
         super(pageSize, getDefaultResources(), keyProvider);
+        getTableBodyElement().getParentElement().addClassName(TableType.DEFAULT.getCssName());
     }
 
     /**
@@ -73,6 +74,7 @@ public class DataGrid<T> extends com.google.gwt.user.cellview.client.DataGrid<T>
      */
     public DataGrid(final int pageSize, final DataGrid.Resources resources) {
         super(pageSize, resources, null);
+        getTableBodyElement().getParentElement().addClassName(TableType.DEFAULT.getCssName());
     }
 
     /**
@@ -88,6 +90,7 @@ public class DataGrid<T> extends com.google.gwt.user.cellview.client.DataGrid<T>
      */
     public DataGrid(final int pageSize, final Resources resources, final ProvidesKey<T> keyProvider, final Widget loadingIndicator) {
         super(pageSize, resources, keyProvider, loadingIndicator);
+        getTableBodyElement().getParentElement().addClassName(TableType.DEFAULT.getCssName());
     }
 
     /**
@@ -257,12 +260,12 @@ public class DataGrid<T> extends com.google.gwt.user.cellview.client.DataGrid<T>
 
         @Override
         public String dataGridHoveredRow() {
-            return DUMMY; // Note: Setting 'active' on the cell disables 'bg-primary'
+            return "active";
         }
 
         @Override
         public String dataGridHoveredRowCell() {
-            return DUMMY; // Note: Setting 'active' on the cell disables 'bg-primary'
+            return "active";
         }
 
         @Override
@@ -307,7 +310,7 @@ public class DataGrid<T> extends com.google.gwt.user.cellview.client.DataGrid<T>
 
         @Override
         public String dataGridSelectedRow() {
-            return "bg-primary"; // Bootstrap3 helper class
+            return "info";
         }
 
         @Override


### PR DESCRIPTION
#186: Set style to 'info' when a row is selected, to be consistent with CellTable and bootstrap3. Also applied 'table' class to correct element so the bootstrap css selector will work as expected when a row is selected.
