### PR TITLE
Revert Text to 0.7-version (Fixes #137)

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Text.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Text.java
@@ -22,6 +22,7 @@ package org.gwtbootstrap3.client.ui.html;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.ui.HasText;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -43,6 +44,7 @@ import com.google.gwt.user.client.ui.Widget;
 public class Text extends Widget implements HasText {
 
     private final com.google.gwt.dom.client.Text text;
+    private boolean isAttached;
 
     /**
      * Creates the default text node with empty text
@@ -75,5 +77,29 @@ public class Text extends Widget implements HasText {
     @Override
     public String getText() {
         return text.getData();
+    }
+    
+    @Override
+    public boolean isAttached() {
+        return isAttached;
+    }
+
+    @Override
+    protected void onAttach() {
+        if (isAttached()) {
+            throw new IllegalStateException("Text is already attached!");
+        }
+        isAttached = true;
+        onLoad();
+        AttachEvent.fire(this, isAttached);
+    }
+
+    @Override
+    protected void onDetach() {
+        if (!isAttached()) {
+            throw new IllegalStateException("Text is not attached!");
+        }
+        isAttached = false;
+        AttachEvent.fire(this, false);
     }
 }


### PR DESCRIPTION
If onAttach/onDetach are not overridden then those are called from widget where
DOM.setEventListener(getElement(), this);
is called.
This method is apparently not available for text nodes in IE8.
