### PR TITLE
Call render() when Icon is set to spin.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/IconTextMixin.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/IconTextMixin.java
@@ -160,6 +160,7 @@ public class IconTextMixin<T extends ComplexWidget & HasText & HasIcon & HasIcon
     @Override
     public void setIconSpin(final boolean iconSpin) {
         this.iconSpin = iconSpin;
+        render();
     }
 
     @Override


### PR DESCRIPTION
- When Icon used in Anchor widgets is set to spin, call render() to actually
  perform change. It's now same as setting Icon's position and other properties.
