### PR TITLE
Fire ValueChangeEvents only if necessary

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/SimpleRadioButton.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/SimpleRadioButton.java
@@ -171,6 +171,10 @@ public class SimpleRadioButton extends com.google.gwt.user.client.ui.SimpleRadio
         super.onBrowserEvent(event);
     }
 
+    /**
+     * No-op. CheckBox's click handler is no good for radio button, so don't use
+     * it. Our event handling is all done in {@link #onBrowserEvent}
+     */
     @Override
     protected void ensureDomEventHandlers() {
     }


### PR DESCRIPTION
Currently the SimpleRadioButton will fire a ValueChangeEvent on every click. This fixes that using the same logic from GWT's RadioButton.
