### PR TITLE
Correct check box and radio button implementations; fixes #216

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBox.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBox.java
@@ -20,32 +20,490 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import org.gwtbootstrap3.client.ui.base.AbstractFormElement;
+import org.gwtbootstrap3.client.ui.base.HasFormValue;
 import org.gwtbootstrap3.client.ui.constants.Styles;
+import org.gwtbootstrap3.client.ui.gwt.ButtonBase;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.InputElement;
+import com.google.gwt.dom.client.LabelElement;
+import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.dom.client.Style.WhiteSpace;
+import com.google.gwt.editor.client.IsEditor;
+import com.google.gwt.editor.client.LeafValueEditor;
+import com.google.gwt.editor.client.adapters.TakesValueEditor;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.i18n.client.HasDirection.Direction;
+import com.google.gwt.i18n.shared.DirectionEstimator;
+import com.google.gwt.i18n.shared.HasDirectionEstimator;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.DirectionalTextHelper;
+import com.google.gwt.user.client.ui.HasDirectionalSafeHtml;
+import com.google.gwt.user.client.ui.HasName;
+import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.HasWordWrap;
 
 /**
- * A checkbox with a label for use within a {@link Form}.
- * <p/>
- * Basically this is a non-styled {@link CheckBoxButton} encapsulated in a {@link org.gwtbootstrap3.client.ui.html.Div}.
- *
- * @author Sven Jacobs
- * @see org.gwtbootstrap3.client.ui.InlineCheckBox
- * @see org.gwtbootstrap3.client.ui.Radio
+ * A standard check box widget.
+ * 
+ * This class also serves as a base class for {@link Radio}.
+ * 
+ * <p>
+ * <h3>Built-in Bidi Text Support</h3>
+ * This widget is capable of automatically adjusting its direction according to
+ * its content. This feature is controlled by {@link #setDirectionEstimator} or
+ * passing a DirectionEstimator parameter to the constructor, and is off by
+ * default.
+ * </p>
  */
-public class CheckBox extends AbstractFormElement {
+public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, HasWordWrap, HasDirectionalSafeHtml,
+        HasDirectionEstimator, IsEditor<LeafValueEditor<Boolean>>, HasFormValue {
 
-    public CheckBox() {
-        super(new CheckBoxButton());
-        setStyleName(Styles.CHECKBOX);
+    protected DirectionalTextHelper directionalTextHelper;
+    protected InputElement inputElem;
+    protected SpanElement labelElem;
+
+    private LeafValueEditor<Boolean> editor;
+    private boolean valueChangeHandlerInitialized;
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     */
+    public CheckBox(SafeHtml label) {
+        this(label.asString(), true);
     }
 
     /**
      * Creates a check box with the specified text label.
-     *
-     * @param label the check box's label
+     * 
+     * @param label
+     *            the check box's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
      */
-    public CheckBox(final String label) {
+    public CheckBox(SafeHtml label, Direction dir) {
+        this();
+        setHTML(label, dir);
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public CheckBox(SafeHtml label, DirectionEstimator directionEstimator) {
+        this();
+        setDirectionEstimator(directionEstimator);
+        setHTML(label.asString());
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     */
+    public CheckBox(String label) {
         this();
         setText(label);
     }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public CheckBox(String label, Direction dir) {
+        this();
+        setText(label, dir);
+    }
+
+    /**
+     * Creates a label with the specified text and a default direction
+     * estimator.
+     * 
+     * @param label
+     *            the check box's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public CheckBox(String label, DirectionEstimator directionEstimator) {
+        this();
+        setDirectionEstimator(directionEstimator);
+        setText(label);
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param asHTML
+     *            <code>true</code> to treat the specified label as html
+     */
+    public CheckBox(String label, boolean asHTML) {
+        this();
+        if (asHTML) {
+            setHTML(label);
+        } else {
+            setText(label);
+        }
+    }
+
+    public CheckBox() {
+        super(DOM.createDiv());
+        setStyleName(Styles.CHECKBOX);
+
+        inputElem = Document.get().createCheckInputElement();
+        labelElem = Document.get().createSpanElement();
+
+        LabelElement label = Document.get().createLabelElement();
+        label.appendChild(inputElem);
+        label.appendChild(labelElem);
+
+        getElement().appendChild(label);
+
+        directionalTextHelper = new DirectionalTextHelper(labelElem, true);
+
+        // Accessibility: setting tab index to be 0 by default, ensuring element
+        // appears in tab sequence. FocusWidget's setElement method already
+        // calls setTabIndex, which is overridden below. However, at the time
+        // that this call is made, inputElem has not been created. So, we have
+        // to call setTabIndex again, once inputElem has been created.
+        setTabIndex(0);
+    }
+
+    protected CheckBox(Element elem) {
+        super(elem);
+    }
+
+    @Override
+    public HandlerRegistration addValueChangeHandler(ValueChangeHandler<Boolean> handler) {
+        // Is this the first value change handler? If so, time to add handlers
+        if (!valueChangeHandlerInitialized) {
+            ensureDomEventHandlers();
+            valueChangeHandlerInitialized = true;
+        }
+        return addHandler(handler, ValueChangeEvent.getType());
+    }
+
+    @Override
+    public LeafValueEditor<Boolean> asEditor() {
+        if (editor == null) {
+            editor = TakesValueEditor.of(this);
+        }
+        return editor;
+    }
+
+    @Override
+    public DirectionEstimator getDirectionEstimator() {
+        return directionalTextHelper.getDirectionEstimator();
+    }
+
+    /**
+     * Returns the value property of the input element that backs this widget.
+     * This is the value that will be associated with the CheckBox name and
+     * submitted to the server if a {@link FormPanel} that holds it is submitted
+     * and the box is checked.
+     * <p>
+     * Don't confuse this with {@link #getValue}, which returns true or false if
+     * the widget is checked.
+     */
+    @Override
+    public String getFormValue() {
+        return inputElem.getValue();
+    }
+
+    @Override
+    public String getHTML() {
+        return directionalTextHelper.getTextOrHtml(true);
+    }
+
+    @Override
+    public String getName() {
+        return inputElem.getName();
+    }
+
+    @Override
+    public int getTabIndex() {
+        return inputElem.getTabIndex();
+    }
+
+    @Override
+    public String getText() {
+        return directionalTextHelper.getTextOrHtml(false);
+    }
+
+    @Override
+    public Direction getTextDirection() {
+        return directionalTextHelper.getTextDirection();
+    }
+
+    /**
+     * Determines whether this check box is currently checked.
+     * <p>
+     * Note that this <em>does not</em> return the value property of the
+     * checkbox input element wrapped by this widget. For access to that
+     * property, see {@link #getFormValue()}
+     * 
+     * @return <code>true</code> if the check box is checked, false otherwise.
+     *         Will not return null
+     */
+    @Override
+    public Boolean getValue() {
+        if (isAttached()) {
+            return inputElem.isChecked();
+        } else {
+            return inputElem.isDefaultChecked();
+        }
+    }
+
+    @Override
+    public boolean getWordWrap() {
+        return !WhiteSpace.NOWRAP.getCssName().equals(getElement().getStyle().getWhiteSpace());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !inputElem.isDisabled();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        inputElem.setDisabled(!enabled);
+        if (enabled) {
+            removeStyleName(Styles.DISABLED);
+        } else {
+            addStyleName(Styles.DISABLED);
+        }
+    }
+
+    @Override
+    public void setAccessKey(char key) {
+        inputElem.setAccessKey("" + key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * See note at {@link #setDirectionEstimator(DirectionEstimator)}.
+     */
+    @Override
+    public void setDirectionEstimator(boolean enabled) {
+        directionalTextHelper.setDirectionEstimator(enabled);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note: DirectionEstimator should be set before the label has any content;
+     * it's highly recommended to set it using a constructor. Reason: if the
+     * label already has non-empty content, this will update its direction
+     * according to the new estimator's result. This may cause flicker, and thus
+     * should be avoided.
+     */
+    @Override
+    public void setDirectionEstimator(DirectionEstimator directionEstimator) {
+        directionalTextHelper.setDirectionEstimator(directionEstimator);
+    }
+
+    @Override
+    public void setFocus(boolean focused) {
+        if (focused) {
+            inputElem.focus();
+        } else {
+            inputElem.blur();
+        }
+    }
+
+    /**
+     * Set the value property on the input element that backs this widget. This
+     * is the value that will be associated with the CheckBox's name and
+     * submitted to the server if a {@link FormPanel} that holds it is submitted
+     * and the box is checked.
+     * <p>
+     * Don't confuse this with {@link #setValue}, which actually checks and
+     * unchecks the box.
+     * 
+     * @param value
+     */
+    @Override
+    public void setFormValue(String value) {
+        inputElem.setValue(value);
+    }
+
+    @Override
+    public void setHTML(SafeHtml html, Direction dir) {
+        directionalTextHelper.setTextOrHtml(html.asString(), dir, true);
+    }
+
+    @Override
+    public void setHTML(String html) {
+        directionalTextHelper.setTextOrHtml(html, true);
+    }
+
+    @Override
+    public void setName(String name) {
+        inputElem.setName(name);
+    }
+
+    @Override
+    public void setTabIndex(int index) {
+        // Need to guard against call to setTabIndex before inputElem is
+        // initialized. This happens because FocusWidget's (a superclass of
+        // CheckBox) setElement method calls setTabIndex before inputElem is
+        // initialized. See CheckBox's protected constructor for more
+        // information.
+        if (inputElem != null) {
+            inputElem.setTabIndex(index);
+        }
+    }
+
+    @Override
+    public void setText(String text) {
+        directionalTextHelper.setTextOrHtml(text, false);
+    }
+
+    @Override
+    public void setText(String text, Direction dir) {
+        directionalTextHelper.setTextOrHtml(text, dir, false);
+    }
+
+    /**
+     * Checks or unchecks the check box.
+     * <p>
+     * Note that this <em>does not</em> set the value property of the checkbox
+     * input element wrapped by this widget. For access to that property, see
+     * {@link #setFormValue(String)}
+     * 
+     * @param value
+     *            true to check, false to uncheck; null value implies false
+     */
+    @Override
+    public void setValue(Boolean value) {
+        setValue(value, false);
+    }
+
+    /**
+     * Checks or unchecks the check box, firing {@link ValueChangeEvent} if
+     * appropriate.
+     * <p>
+     * Note that this <em>does not</em> set the value property of the checkbox
+     * input element wrapped by this widget. For access to that property, see
+     * {@link #setFormValue(String)}
+     * 
+     * @param value
+     *            true to check, false to uncheck; null value implies false
+     * @param fireEvents
+     *            If true, and value has changed, fire a
+     *            {@link ValueChangeEvent}
+     */
+    @Override
+    public void setValue(Boolean value, boolean fireEvents) {
+        if (value == null) {
+            value = Boolean.FALSE;
+        }
+
+        Boolean oldValue = getValue();
+        inputElem.setChecked(value);
+        inputElem.setDefaultChecked(value);
+        if (value.equals(oldValue)) {
+            return;
+        }
+        if (fireEvents) {
+            ValueChangeEvent.fire(this, value);
+        }
+    }
+
+    @Override
+    public void setWordWrap(boolean wrap) {
+        getElement().getStyle().setWhiteSpace(wrap ? WhiteSpace.NORMAL : WhiteSpace.NOWRAP);
+    }
+
+    // Unlike other widgets the CheckBox sinks on its inputElement, not
+    // its wrapper
+    @Override
+    public void sinkEvents(int eventBitsToAdd) {
+        if (isOrWasAttached()) {
+            Event.sinkEvents(inputElem, eventBitsToAdd | Event.getEventsSunk(inputElem));
+        } else {
+            super.sinkEvents(eventBitsToAdd);
+        }
+    }
+
+    protected void ensureDomEventHandlers() {
+        addClickHandler(new ClickHandler() {
+
+            @Override
+            public void onClick(ClickEvent event) {
+                // Checkboxes always toggle their value, no need to compare
+                // with old value. Radio buttons are not so lucky, see
+                // overrides in RadioButton
+                ValueChangeEvent.fire(CheckBox.this, getValue());
+            }
+        });
+    }
+
+    /**
+     * <b>Affected Elements:</b>
+     * <ul>
+     * <li>-input = checkbox.</li>
+     * </ul>
+     * 
+     * @see UIObject#onEnsureDebugId(String)
+     */
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+        ensureDebugId(inputElem, baseID, "input");
+    }
+
+    /**
+     * This method is called when a widget is attached to the browser's
+     * document. onAttach needs special handling for the CheckBox case. Must
+     * still call {@link Widget#onAttach()} to preserve the
+     * <code>onAttach</code> contract.
+     */
+    @Override
+    protected void onLoad() {
+        DOM.setEventListener(inputElem, this);
+    }
+
+    /**
+     * This method is called when a widget is detached from the browser's
+     * document. Overridden because of IE bug that throws away checked state and
+     * in order to clear the event listener off of the <code>inputElem</code>.
+     */
+    @Override
+    protected void onUnload() {
+        // Clear out the inputElem's event listener (breaking the circular
+        // reference between it and the widget).
+        DOM.setEventListener(inputElem, null);
+        setValue(getValue());
+    }
+
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBoxButton.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBoxButton.java
@@ -20,23 +20,191 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import org.gwtbootstrap3.client.ui.base.button.AbstractLabelButton;
-import org.gwtbootstrap3.client.ui.constants.TypeAttrType;
+import org.gwtbootstrap3.client.ui.base.HasActive;
+import org.gwtbootstrap3.client.ui.base.HasSize;
+import org.gwtbootstrap3.client.ui.base.HasType;
+import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
+import org.gwtbootstrap3.client.ui.base.mixin.ActiveMixin;
+import org.gwtbootstrap3.client.ui.constants.ButtonSize;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.Styles;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.InputElement;
+import com.google.gwt.i18n.client.HasDirection.Direction;
+import com.google.gwt.i18n.shared.DirectionEstimator;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.ui.DirectionalTextHelper;
 
 /**
- * Button representing a checkbox used within a {@link ButtonGroup} that has toggle set to {@code Toogle.BUTTONS}.
+ * Button representing a checkbox used within a {@link ButtonGroup} that has
+ * toggle set to {@code Toogle.BUTTONS}.
  * <p/>
  * If you are looking for a classic checkbox see {@link CheckBox}.
  *
  * @author Sven Jacobs
  */
-public class CheckBoxButton extends AbstractLabelButton {
+public class CheckBoxButton extends CheckBox implements HasActive, HasType<ButtonType>, HasSize<ButtonSize> {
+
+    private final ActiveMixin<CheckBoxButton> activeMixin = new ActiveMixin<CheckBoxButton>(this);
+
+    /**
+     * Creates a check box button with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     */
+    public CheckBoxButton(SafeHtml label) {
+        this(label.asString(), true);
+    }
+
+    /**
+     * Creates a check box button with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public CheckBoxButton(SafeHtml label, Direction dir) {
+        this();
+        setHTML(label, dir);
+    }
+
+    /**
+     * Creates a check box button with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public CheckBoxButton(SafeHtml label, DirectionEstimator directionEstimator) {
+        this();
+        setDirectionEstimator(directionEstimator);
+        setHTML(label.asString());
+    }
+
+    /**
+     * Creates a check box button with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     */
+    public CheckBoxButton(String label) {
+        this();
+        setText(label);
+    }
+
+    /**
+     * Creates a check box button with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public CheckBoxButton(String label, Direction dir) {
+        this();
+        setText(label, dir);
+    }
+
+    /**
+     * Creates a label with the specified text and a default direction
+     * estimator.
+     * 
+     * @param label
+     *            the check box's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public CheckBoxButton(String label, DirectionEstimator directionEstimator) {
+        this();
+        setDirectionEstimator(directionEstimator);
+        setText(label);
+    }
+
+    /**
+     * Creates a check box button with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param asHTML
+     *            <code>true</code> to treat the specified label as html
+     */
+    public CheckBoxButton(String label, boolean asHTML) {
+        this();
+        if (asHTML) {
+            setHTML(label);
+        } else {
+            setText(label);
+        }
+    }
 
     public CheckBoxButton() {
-        super(TypeAttrType.CHECKBOX);
+        this(Document.get().createCheckInputElement());
     }
 
-    public CheckBoxButton(final String label) {
-        super(TypeAttrType.CHECKBOX, label);
+    protected CheckBoxButton(InputElement elem) {
+        super(DOM.createLabel());
+
+        setStyleName(Styles.BTN);
+        setType(ButtonType.DEFAULT);
+
+        inputElem = elem;
+        labelElem = Document.get().createSpanElement();
+
+        getElement().appendChild(inputElem);
+        getElement().appendChild(labelElem);
+
+        directionalTextHelper = new DirectionalTextHelper(labelElem, true);
+
+        // Accessibility: setting tab index to be 0 by default, ensuring element
+        // appears in tab sequence. FocusWidget's setElement method already
+        // calls setTabIndex, which is overridden below. However, at the time
+        // that this call is made, inputElem has not been created. So, we have
+        // to call setTabIndex again, once inputElem has been created.
+        setTabIndex(0);
     }
+
+    @Override
+    public void setSize(ButtonSize size) {
+        StyleHelper.addUniqueEnumStyleName(this, ButtonSize.class, size);
+    }
+
+    @Override
+    public ButtonSize getSize() {
+        return ButtonSize.fromStyleName(getStyleName());
+    }
+
+    @Override
+    public void setType(ButtonType type) {
+        StyleHelper.addUniqueEnumStyleName(this, ButtonType.class, type);
+    }
+
+    @Override
+    public ButtonType getType() {
+        return ButtonType.fromStyleName(getStyleName());
+    }
+
+    @Override
+    public void setActive(boolean active) {
+        setValue(active);
+        activeMixin.setActive(active);
+    }
+
+    @Override
+    public boolean isActive() {
+        return activeMixin.isActive();
+    }
+
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineCheckBox.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineCheckBox.java
@@ -22,24 +22,140 @@ package org.gwtbootstrap3.client.ui;
 
 import org.gwtbootstrap3.client.ui.constants.Styles;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.i18n.client.HasDirection.Direction;
+import com.google.gwt.i18n.shared.DirectionEstimator;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.ui.DirectionalTextHelper;
+
 /**
- * An inline checkbox with a label for use within a {@link Form}.
- * Multiple InlineCheckBox in the same container will be displayed in one line.
- * <p/>
- * Basically this is a non-styled {@link CheckBoxButton}.
+ * An inline check box widget.
  *
  * @author Sven Jacobs
  * @see org.gwtbootstrap3.client.ui.CheckBox
- * @see org.gwtbootstrap3.client.ui.CheckBoxButton
  */
-public class InlineCheckBox extends CheckBoxButton {
+public class InlineCheckBox extends CheckBox {
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     */
+    public InlineCheckBox(SafeHtml label) {
+        this(label.asString(), true);
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public InlineCheckBox(SafeHtml label, Direction dir) {
+        this();
+        setHTML(label, dir);
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public InlineCheckBox(SafeHtml label, DirectionEstimator directionEstimator) {
+        this();
+        setDirectionEstimator(directionEstimator);
+        setHTML(label.asString());
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     */
+    public InlineCheckBox(String label) {
+        this();
+        setText(label);
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public InlineCheckBox(String label, Direction dir) {
+        this();
+        setText(label, dir);
+    }
+
+    /**
+     * Creates a label with the specified text and a default direction
+     * estimator.
+     * 
+     * @param label
+     *            the check box's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public InlineCheckBox(String label, DirectionEstimator directionEstimator) {
+        this();
+        setDirectionEstimator(directionEstimator);
+        setText(label);
+    }
+
+    /**
+     * Creates a check box with the specified text label.
+     * 
+     * @param label
+     *            the check box's label
+     * @param asHTML
+     *            <code>true</code> to treat the specified label as html
+     */
+    public InlineCheckBox(String label, boolean asHTML) {
+        this();
+        if (asHTML) {
+            setHTML(label);
+        } else {
+            setText(label);
+        }
+    }
 
     public InlineCheckBox() {
+        super(DOM.createLabel());
         setStyleName(Styles.CHECKBOX_INLINE);
+
+        inputElem = Document.get().createCheckInputElement();
+        labelElem = Document.get().createSpanElement();
+
+        getElement().appendChild(inputElem);
+        getElement().appendChild(labelElem);
+
+        directionalTextHelper = new DirectionalTextHelper(labelElem, true);
+
+        // Accessibility: setting tab index to be 0 by default, ensuring element
+        // appears in tab sequence. FocusWidget's setElement method already
+        // calls setTabIndex, which is overridden below. However, at the time
+        // that this call is made, inputElem has not been created. So, we have
+        // to call setTabIndex again, once inputElem has been created.
+        setTabIndex(0);
     }
 
-    public InlineCheckBox(final String label) {
-        super(label);
-        setStyleName(Styles.CHECKBOX_INLINE);
-    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineRadio.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineRadio.java
@@ -22,24 +22,188 @@ package org.gwtbootstrap3.client.ui;
 
 import org.gwtbootstrap3.client.ui.constants.Styles;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.i18n.client.HasDirection.Direction;
+import com.google.gwt.i18n.shared.DirectionEstimator;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.uibinder.client.UiConstructor;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.DirectionalTextHelper;
+
 /**
- * An inline radio element with a label for use within a {@link Form}.
- * Multiple InlineRadio in the same container will be displayed in one line.
- * <p/>
- * Basically this is a non-styled {@link RadioButton}.
+ * An inline radio button widget.
  *
  * @author Sven Jacobs
  * @see org.gwtbootstrap3.client.ui.Radio
- * @see org.gwtbootstrap3.client.ui.RadioButton
  */
-public class InlineRadio extends RadioButton {
+public class InlineRadio extends Radio {
 
-    public InlineRadio() {
-        setStyleName(Styles.RADIO_INLINE);
+    /**
+     * Creates a new radio associated with a particular group, and initialized
+     * with the given HTML label. All radio buttons associated with the same
+     * group name belong to a mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     */
+    public InlineRadio(String name, SafeHtml label) {
+        this(name, label.asString(), true);
     }
 
-    public InlineRadio(final String label) {
-        super(label);
-        setStyleName(Styles.RADIO_INLINE);
+    /**
+     * @see #InlineRadio(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public InlineRadio(String name, SafeHtml label, Direction dir) {
+        this(name);
+        setHTML(label, dir);
     }
+
+    /**
+     * @see #InlineRadio(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public InlineRadio(String name, SafeHtml label, DirectionEstimator directionEstimator) {
+        this(name);
+        setDirectionEstimator(directionEstimator);
+        setHTML(label.asString());
+    }
+
+    /**
+     * Creates a new radio associated with a particular group, and initialized
+     * with the given HTML label. All radio buttons associated with the same
+     * group name belong to a mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     */
+    public InlineRadio(String name, String label) {
+        this(name);
+        setText(label);
+    }
+
+    /**
+     * @see #InlineRadio(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public InlineRadio(String name, String label, Direction dir) {
+        this(name);
+        setText(label, dir);
+    }
+
+    /**
+     * @see #InlineRadio(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public InlineRadio(String name, String label, DirectionEstimator directionEstimator) {
+        this(name);
+        setDirectionEstimator(directionEstimator);
+        setText(label);
+    }
+
+    /**
+     * Creates a new radio button associated with a particular group, and
+     * initialized with the given label (optionally treated as HTML). All radio
+     * buttons associated with the same group name belong to a
+     * mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            name the group with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param asHTML
+     *            <code>true</code> to treat the specified label as HTML
+     */
+    public InlineRadio(String name, String label, boolean asHTML) {
+        this(name);
+        if (asHTML) {
+            setHTML(label);
+        } else {
+            setText(label);
+        }
+    }
+
+    /**
+     * Creates a new radio associated with a particular group name. All radio
+     * buttons associated with the same group name belong to a
+     * mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     */
+    @UiConstructor
+    public InlineRadio(String name) {
+        super(DOM.createLabel());
+        setStyleName(Styles.RADIO_INLINE);
+
+        inputElem = Document.get().createRadioInputElement(name);
+        labelElem = Document.get().createSpanElement();
+
+        getElement().appendChild(inputElem);
+        getElement().appendChild(labelElem);
+
+        directionalTextHelper = new DirectionalTextHelper(labelElem, true);
+
+        // Accessibility: setting tab index to be 0 by default, ensuring element
+        // appears in tab sequence. FocusWidget's setElement method already
+        // calls setTabIndex, which is overridden below. However, at the time
+        // that this call is made, inputElem has not been created. So, we have
+        // to call setTabIndex again, once inputElem has been created.
+        setTabIndex(0);
+
+        sinkEvents(Event.ONCLICK);
+        sinkEvents(Event.ONMOUSEUP);
+        sinkEvents(Event.ONBLUR);
+        sinkEvents(Event.ONKEYDOWN);
+    }
+
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Radio.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Radio.java
@@ -20,32 +20,289 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import org.gwtbootstrap3.client.ui.base.AbstractFormElement;
 import org.gwtbootstrap3.client.ui.constants.Styles;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.EventTarget;
+import com.google.gwt.dom.client.LabelElement;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.i18n.client.HasDirection.Direction;
+import com.google.gwt.i18n.shared.DirectionEstimator;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.uibinder.client.UiConstructor;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.DirectionalTextHelper;
+
 /**
- * A radio element with a label for use within a {@link Form}.
- * <p/>
- * Basically this is a non-styled {@link RadioButton} encapsulated in a {@link org.gwtbootstrap3.client.ui.html.Div}.
+ * A mutually-exclusive selection radio button widget. Fires
+ * {@link com.google.gwt.event.dom.client.ClickEvent ClickEvents} when the radio
+ * button is clicked, and {@link ValueChangeEvent ValueChangeEvents} when the
+ * button becomes checked. Note, however, that browser limitations prevent
+ * ValueChangeEvents from being sent when the radio button is cleared as a side
+ * effect of another in the group being clicked.
+ * 
+ * <p>
+ * <h3>Built-in Bidi Text Support</h3>
+ * This widget is capable of automatically adjusting its direction according to
+ * its content. This feature is controlled by {@link #setDirectionEstimator} or
+ * passing a DirectionEstimator parameter to the constructor, and is off by
+ * default.
+ * </p>
  *
  * @author Sven Jacobs
- * @see org.gwtbootstrap3.client.ui.InlineRadio
- * @see org.gwtbootstrap3.client.ui.CheckBox
  */
-public class Radio extends AbstractFormElement {
+public class Radio extends CheckBox {
 
-    public Radio() {
-        super(new RadioButton());
-        setStyleName(Styles.RADIO);
+    private Boolean oldValue;
+
+    /**
+     * Creates a new radio associated with a particular group, and initialized
+     * with the given HTML label. All radio buttons associated with the same
+     * group name belong to a mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     */
+    public Radio(String name, SafeHtml label) {
+        this(name, label.asString(), true);
     }
 
     /**
-     * Creates a check box with the specified text label.
-     *
-     * @param label the check box's label
+     * @see #RadioButton(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
      */
-    public Radio(final String label) {
-        this();
+    public Radio(String name, SafeHtml label, Direction dir) {
+        this(name);
+        setHTML(label, dir);
+    }
+
+    /**
+     * @see #RadioButton(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public Radio(String name, SafeHtml label, DirectionEstimator directionEstimator) {
+        this(name);
+        setDirectionEstimator(directionEstimator);
+        setHTML(label.asString());
+    }
+
+    /**
+     * Creates a new radio associated with a particular group, and initialized
+     * with the given HTML label. All radio buttons associated with the same
+     * group name belong to a mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     */
+    public Radio(String name, String label) {
+        this(name);
         setText(label);
+    }
+
+    /**
+     * @see #RadioButton(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public Radio(String name, String label, Direction dir) {
+        this(name);
+        setText(label, dir);
+    }
+
+    /**
+     * @see #RadioButton(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public Radio(String name, String label, DirectionEstimator directionEstimator) {
+        this(name);
+        setDirectionEstimator(directionEstimator);
+        setText(label);
+    }
+
+    /**
+     * Creates a new radio button associated with a particular group, and
+     * initialized with the given label (optionally treated as HTML). All radio
+     * buttons associated with the same group name belong to a
+     * mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            name the group with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param asHTML
+     *            <code>true</code> to treat the specified label as HTML
+     */
+    public Radio(String name, String label, boolean asHTML) {
+        this(name);
+        if (asHTML) {
+            setHTML(label);
+        } else {
+            setText(label);
+        }
+    }
+
+    /**
+     * Creates a new radio associated with a particular group name. All radio
+     * buttons associated with the same group name belong to a
+     * mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     */
+    @UiConstructor
+    public Radio(String name) {
+        super(DOM.createDiv());
+        setStyleName(Styles.RADIO);
+
+        LabelElement label = Document.get().createLabelElement();
+        inputElem = Document.get().createRadioInputElement(name);
+        labelElem = Document.get().createSpanElement();
+
+        label.appendChild(inputElem);
+        label.appendChild(labelElem);
+
+        getElement().appendChild(label);
+
+        directionalTextHelper = new DirectionalTextHelper(labelElem, true);
+
+        // Accessibility: setting tab index to be 0 by default, ensuring element
+        // appears in tab sequence. FocusWidget's setElement method already
+        // calls setTabIndex, which is overridden below. However, at the time
+        // that this call is made, inputElem has not been created. So, we have
+        // to call setTabIndex again, once inputElem has been created.
+        setTabIndex(0);
+
+        sinkEvents(Event.ONCLICK);
+        sinkEvents(Event.ONMOUSEUP);
+        sinkEvents(Event.ONBLUR);
+        sinkEvents(Event.ONKEYDOWN);
+    }
+
+    protected Radio(Element elem) {
+        super(elem);
+    }
+
+    /**
+     * Overridden to send ValueChangeEvents only when appropriate.
+     */
+    @Override
+    public void onBrowserEvent(Event event) {
+        switch (DOM.eventGetType(event)) {
+        case Event.ONMOUSEUP:
+        case Event.ONBLUR:
+        case Event.ONKEYDOWN:
+            // Note the old value for onValueChange purposes (in ONCLICK case)
+            oldValue = getValue();
+            break;
+
+        case Event.ONCLICK:
+            EventTarget target = event.getEventTarget();
+            if (Element.is(target) && labelElem.isOrHasChild(Element.as(target))) {
+
+                // They clicked the label. Note our pre-click value, and
+                // short circuit event routing so that other click handlers
+                // don't hear about it
+                oldValue = getValue();
+                return;
+            }
+
+            // It's not the label. Let our handlers hear about the
+            // click...
+            super.onBrowserEvent(event);
+            // ...and now maybe tell them about the change
+            ValueChangeEvent.fireIfNotEqual(Radio.this, oldValue, getValue());
+            return;
+        }
+
+        super.onBrowserEvent(event);
+    }
+
+    /**
+     * Change the group name of this radio button.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * If changing this group name results in a new radio group with multiple
+     * radio buttons selected, this radio button will remain selected and the
+     * other radio buttons will be unselected.
+     * 
+     * @param name
+     *            name the group with which to associate the radio button
+     */
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+    }
+
+    @Override
+    public void sinkEvents(int eventBitsToAdd) {
+        // Like CheckBox, we want to hear about inputElem. We
+        // also want to know what's going on with the label, to
+        // make sure onBrowserEvent is able to record value changes
+        // initiated by label events
+        if (isOrWasAttached()) {
+            Event.sinkEvents(inputElem, eventBitsToAdd | Event.getEventsSunk(inputElem));
+            Event.sinkEvents(labelElem, eventBitsToAdd | Event.getEventsSunk(labelElem));
+        } else {
+            super.sinkEvents(eventBitsToAdd);
+        }
+    }
+
+    /**
+     * No-op. CheckBox's click handler is no good for radio button, so don't use
+     * it. Our event handling is all done in {@link #onBrowserEvent}
+     */
+    @Override
+    protected void ensureDomEventHandlers() {
     }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/RadioButton.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/RadioButton.java
@@ -20,24 +20,196 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import org.gwtbootstrap3.client.ui.base.button.AbstractLabelButton;
-import org.gwtbootstrap3.client.ui.constants.TypeAttrType;
+import org.gwtbootstrap3.client.ui.base.HasActive;
+import org.gwtbootstrap3.client.ui.base.HasSize;
+import org.gwtbootstrap3.client.ui.base.HasType;
+import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
+import org.gwtbootstrap3.client.ui.base.mixin.ActiveMixin;
+import org.gwtbootstrap3.client.ui.constants.ButtonSize;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.i18n.client.HasDirection.Direction;
+import com.google.gwt.i18n.shared.DirectionEstimator;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.uibinder.client.UiConstructor;
 
 /**
- * Button representing a radio box.
+ * Button representing a radio button used within a {@link ButtonGroup} that has
+ * toggle set to {@code Toogle.BUTTONS}.
  * <p/>
- * Used within a {@link ButtonGroup} that
- * has toggle set to {@code Toogle.BUTTONS}.
+ * If you are looking for a classic radio button see {@link RadioButton}.
  *
  * @author Sven Jacobs
  */
-public class RadioButton extends AbstractLabelButton {
+public class RadioButton extends Radio implements HasActive, HasType<ButtonType>, HasSize<ButtonSize> {
 
-    public RadioButton() {
-        super(TypeAttrType.RADIO);
+    private final ActiveMixin<RadioButton> activeMixin = new ActiveMixin<RadioButton>(this);
+
+    /**
+     * Creates a new radio associated with a particular group, and initialized
+     * with the given HTML label. All radio buttons associated with the same
+     * group name belong to a mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     */
+    public RadioButton(String name, SafeHtml label) {
+        this(name, label.asString(), true);
     }
 
-    public RadioButton(final String label) {
-        super(TypeAttrType.RADIO, label);
+    /**
+     * @see #RadioButtonToggle(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public RadioButton(String name, SafeHtml label, Direction dir) {
+        this(name);
+        setHTML(label, dir);
     }
+
+    /**
+     * @see #RadioButtonToggle(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's html label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public RadioButton(String name, SafeHtml label, DirectionEstimator directionEstimator) {
+        this(name);
+        setDirectionEstimator(directionEstimator);
+        setHTML(label.asString());
+    }
+
+    /**
+     * Creates a new radio associated with a particular group, and initialized
+     * with the given HTML label. All radio buttons associated with the same
+     * group name belong to a mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     */
+    public RadioButton(String name, String label) {
+        this(name);
+        setText(label);
+    }
+
+    /**
+     * @see #RadioButtonToggle(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param dir
+     *            the text's direction. Note that {@code DEFAULT} means
+     *            direction should be inherited from the widget's parent
+     *            element.
+     */
+    public RadioButton(String name, String label, Direction dir) {
+        this(name);
+        setText(label, dir);
+    }
+
+    /**
+     * @see #RadioButtonToggle(String, SafeHtml)
+     * 
+     * @param name
+     *            the group name with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param directionEstimator
+     *            A DirectionEstimator object used for automatic direction
+     *            adjustment. For convenience,
+     *            {@link #DEFAULT_DIRECTION_ESTIMATOR} can be used.
+     */
+    public RadioButton(String name, String label, DirectionEstimator directionEstimator) {
+        this(name);
+        setDirectionEstimator(directionEstimator);
+        setText(label);
+    }
+
+    /**
+     * Creates a new radio button associated with a particular group, and
+     * initialized with the given label (optionally treated as HTML). All radio
+     * buttons associated with the same group name belong to a
+     * mutually-exclusive set.
+     * 
+     * Radio buttons are grouped by their name attribute, so changing their name
+     * using the setName() method will also change their associated group.
+     * 
+     * @param name
+     *            name the group with which to associate the radio button
+     * @param label
+     *            this radio button's label
+     * @param asHTML
+     *            <code>true</code> to treat the specified label as HTML
+     */
+    public RadioButton(String name, String label, boolean asHTML) {
+        this(name);
+        if (asHTML) {
+            setHTML(label);
+        } else {
+            setText(label);
+        }
+    }
+
+    @UiConstructor
+    public RadioButton(String name) {
+        super(Document.get().createRadioInputElement(name));
+    }
+
+    @Override
+    public void setSize(ButtonSize size) {
+        StyleHelper.addUniqueEnumStyleName(this, ButtonSize.class, size);
+    }
+
+    @Override
+    public ButtonSize getSize() {
+        return ButtonSize.fromStyleName(getStyleName());
+    }
+
+    @Override
+    public void setType(ButtonType type) {
+        StyleHelper.addUniqueEnumStyleName(this, ButtonType.class, type);
+    }
+
+    @Override
+    public ButtonType getType() {
+        return ButtonType.fromStyleName(getStyleName());
+    }
+
+    @Override
+    public void setActive(boolean active) {
+        setValue(active);
+        activeMixin.setActive(active);
+    }
+
+    @Override
+    public boolean isActive() {
+        return activeMixin.isActive();
+    }
+
 }


### PR DESCRIPTION
Here we go again :)

Due to #216 I reviewed the `CheckBox`/`Radio` implementations and found a few problems. The following classes are the center of attention:
- `CheckBox`  
  `<div class="checkbox"><label><input type="checkbox"> Check</label></div>`
- `InlineCheckBox`  
  `<label class="checkbox-inline"><input type="checkbox"> Check</label>`
- `CheckBoxButton`  
  `<label class="btn btn-primary"><input type="checkbox"> Check</label>`
- `Radio`  
  `<div class="radio"><label><input type="radio"> Radio</label></div>`
- `InlineRadio`  
  `<label class="radio-inline"><input type="radio"> Radio</label>`
- `RadioButton`  
  `<label class="btn btn-primary"><input type="radio"> Radio</label>`
# Bad supertypes

`InputButton` implements `HasText`, `HasIcon`, `HasIconPosition` due to extending AbstractIconButton. Neither an `<input type="checkbox">` nor an `<input type="radio">` allow for child elements. Therefore it is unnecessary. Similarly for `HasDataToggle`, `HasType<ButtonType>`, `HasSize<ButtonSize>` and `HasDataTarget`. This actually leads to the problems of #216.

`InputButton` should only extend `FocusWidget` similarly to `SimpleCheckBox`. Thinking of `SimpleCheckBox`: It is actually possible to use GWT `SimpleCheckBox` in replacement of `CheckableInputButton`. Change the constructor of `AbstractLabelButton` to

```
protected final SimpleCheckBox input;

protected AbstractLabelButton(final SimpleCheckBox input) {
    super(ButtonType.DEFAULT);
    this.input = input;
}
```

and pass new `SimpleRadioButton()` instead of `TypeAttr.RADIO` from e.g. `RadioButton`'s constructor. That would be a good solution: only about 30 lines of code changed and everything works.

You can see that in my [branch checkbox-fix-2](https://github.com/ArloL/gwtbootstrap3/tree/checkbox-fix-2).

Sadly not everything works:
# Handling of `ValueChangeEvent`

`CheckableInputButton` uses the change event to trigger `ValueChangeEvent`s. In modern browsers you can use a change event and everything works as expected. But IE 8 does not follow the same contract calling for solutions like using a `ClickHandler` in `CheckBox`, or manually parsing events like in GWT `RadioButton` or #226 for `SimpleRadioButton`.

Weirdly a `ClickHandler` does not get triggered for `CheckBoxButton`. My guess is that it's because the element is not visible. When you add a `ClickHandler` to the label you will trigger two `ValueChangeEvent`s in `CheckBox` because you clicked on the `<label>` and the `<input>` changed.

You can see that in my [branch checkbox-fix-3](https://github.com/ArloL/gwtbootstrap3/tree/checkbox-fix-3).

I don't see an easy fix for this.

In my PR I use a similar solution to #226.
# Unnecessarily complex structure

This is the current structure:
- `AbstractFormElement`
  - `CheckBox` uses `CheckBoxButton`
  - `Radio` uses `RadioButton`
- `AbstractLabelButton` uses `CheckableInputButton`
  - `CheckBoxButton`
    - `InlineCheckBox`
  - `RadioButton`
    - `InlineRadio`
- `InputButton`
  - `CheckableInputButton`

The proposed structure looks like this:
-   `CheckBox`
  -   `CheckBoxButton`
  - `InlineCheckBox`
  - `Radio`
    - `RadioButton`
    - `InlineRadio`
# Missing interfaces

In comparison with GWT `CheckBox` the current implementation is missing: `HasWordWrap`, `HasDirectionalSafeHtml` and `HasDirectionEstimator`.

This PR fixes that.
# Testing

I have tested the PR in IE 10, IE 10 in IE 8 compatibility mode and Chrome.
# Further discussion

The current implementation of InputGroupAddon for check box and radio is wrong. Bootstrap uses a simple [input instead of a button](http://getbootstrap.com/components/#input-groups-checkboxes-radios).

GWT Compatibility: GWT does not use the ChangeHandler for legacy reasons. This actually breaks some stuff in modern browsers. E.g. selecting a radio button with the keyboard does not properly trigger `ValueChangeEvent`s. The more I think about it the less I am convinced of workarounds using `ClickHandler` and #216.
