### PR TITLE
IE 8 specific CheckBox and Radio

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBox.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBox.java
@@ -23,7 +23,9 @@ package org.gwtbootstrap3.client.ui;
 import org.gwtbootstrap3.client.ui.base.HasFormValue;
 import org.gwtbootstrap3.client.ui.constants.Styles;
 import org.gwtbootstrap3.client.ui.gwt.ButtonBase;
+import org.gwtbootstrap3.client.ui.impl.CheckBoxImpl;
 
+import com.google.gwt.core.shared.GWT;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.InputElement;
@@ -35,8 +37,6 @@ import com.google.gwt.editor.client.LeafValueEditor;
 import com.google.gwt.editor.client.adapters.TakesValueEditor;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
@@ -68,6 +68,8 @@ import com.google.gwt.user.client.ui.HasWordWrap;
  */
 public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, HasWordWrap, HasDirectionalSafeHtml,
         HasDirectionEstimator, IsEditor<LeafValueEditor<Boolean>>, HasFormValue, HasChangeHandlers {
+
+    private static final CheckBoxImpl impl = GWT.create(CheckBoxImpl.class);
 
     protected DirectionalTextHelper directionalTextHelper;
     protected InputElement inputElem;
@@ -464,16 +466,7 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
     }
 
     protected void ensureDomEventHandlers() {
-        addClickHandler(new ClickHandler() {
-
-            @Override
-            public void onClick(ClickEvent event) {
-                // Checkboxes always toggle their value, no need to compare
-                // with old value. Radio buttons are not so lucky, see
-                // overrides in RadioButton
-                ValueChangeEvent.fire(CheckBox.this, getValue());
-            }
-        });
+        impl.ensureDomEventHandlers(this);
     }
 
     /**

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBox.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBox.java
@@ -33,8 +33,11 @@ import com.google.gwt.dom.client.Style.WhiteSpace;
 import com.google.gwt.editor.client.IsEditor;
 import com.google.gwt.editor.client.LeafValueEditor;
 import com.google.gwt.editor.client.adapters.TakesValueEditor;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.HasChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -64,7 +67,7 @@ import com.google.gwt.user.client.ui.HasWordWrap;
  * </p>
  */
 public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, HasWordWrap, HasDirectionalSafeHtml,
-        HasDirectionEstimator, IsEditor<LeafValueEditor<Boolean>>, HasFormValue {
+        HasDirectionEstimator, IsEditor<LeafValueEditor<Boolean>>, HasFormValue, HasChangeHandlers {
 
     protected DirectionalTextHelper directionalTextHelper;
     protected InputElement inputElem;
@@ -209,6 +212,11 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
             valueChangeHandlerInitialized = true;
         }
         return addHandler(handler, ValueChangeEvent.getType());
+    }
+
+    @Override
+    public HandlerRegistration addChangeHandler(ChangeHandler handler) {
+        return addDomHandler(handler, ChangeEvent.getType());
     }
 
     @Override

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/CheckBoxImpl.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/CheckBoxImpl.java
@@ -1,0 +1,42 @@
+package org.gwtbootstrap3.client.ui.impl;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.gwtbootstrap3.client.ui.CheckBox;
+
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+
+public class CheckBoxImpl {
+
+    public void ensureDomEventHandlers(final CheckBox checkBox) {
+        checkBox.addChangeHandler(new ChangeHandler() {
+
+            @Override
+            public void onChange(ChangeEvent event) {
+                ValueChangeEvent.fire(checkBox, checkBox.getValue());
+            }
+
+        });
+    }
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/CheckBoxImplIE8.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/CheckBoxImplIE8.java
@@ -1,0 +1,43 @@
+package org.gwtbootstrap3.client.ui.impl;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.gwtbootstrap3.client.ui.CheckBox;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+
+public class CheckBoxImplIE8 extends CheckBoxImpl {
+
+    @Override
+    public void ensureDomEventHandlers(final CheckBox checkBox) {
+        checkBox.addClickHandler(new ClickHandler() {
+
+            @Override
+            public void onClick(ClickEvent event) {
+                ValueChangeEvent.fire(checkBox, checkBox.getValue());
+            }
+
+        });
+    }
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/RadioImpl.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/RadioImpl.java
@@ -1,0 +1,50 @@
+package org.gwtbootstrap3.client.ui.impl;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.gwtbootstrap3.client.ui.Radio;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.user.client.Event;
+
+public class RadioImpl {
+
+    public void ensureDomEventHandlers(final Radio radio) {
+        radio.addChangeHandler(new ChangeHandler() {
+
+            @Override
+            public void onChange(ChangeEvent event) {
+                ValueChangeEvent.fire(radio, radio.getValue());
+            }
+
+        });
+    }
+
+    public void sinkEvents(int eventBitsToAdd, Element inputElem,
+            @SuppressWarnings("unused") Element labelElem) {
+        Event.sinkEvents(inputElem,
+                eventBitsToAdd | Event.getEventsSunk(inputElem));
+    }
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/RadioImplIE8.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/RadioImplIE8.java
@@ -34,6 +34,19 @@ import com.google.gwt.event.dom.client.MouseUpHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.user.client.Event;
 
+/**
+ * This implementation will work in most cases.
+ *
+ * This case is not supported:
+ *
+ * 1. Given a group of two Radios
+ * 2. Select the first with a click on either input or label
+ * 3. Select the second with a click on either input or label
+ * 4. Select the first using the keyboard
+ *
+ * You will notice that 4 does not trigger a ValueChangeEvent.
+ *
+ */
 public class RadioImplIE8 extends RadioImpl {
 
     private static class Handler implements ClickHandler, MouseUpHandler, BlurHandler, KeyDownHandler {

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/RadioImplIE8.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/impl/RadioImplIE8.java
@@ -1,0 +1,88 @@
+package org.gwtbootstrap3.client.ui.impl;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.gwtbootstrap3.client.ui.Radio;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.MouseUpEvent;
+import com.google.gwt.event.dom.client.MouseUpHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.user.client.Event;
+
+public class RadioImplIE8 extends RadioImpl {
+
+    private static class Handler implements ClickHandler, MouseUpHandler, BlurHandler, KeyDownHandler {
+
+        private final Radio radio;
+        private Boolean oldValue;
+
+        public Handler(Radio radio) {
+            this.radio = radio;
+        }
+
+        @Override
+        public void onClick(ClickEvent event) {
+            ValueChangeEvent.fireIfNotEqual(radio, oldValue, radio.getValue());
+        }
+
+        @Override
+        public void onKeyDown(KeyDownEvent event) {
+            oldValue = radio.getValue();
+        }
+
+        @Override
+        public void onBlur(BlurEvent event) {
+            oldValue = radio.getValue();
+        }
+
+        @Override
+        public void onMouseUp(MouseUpEvent event) {
+            oldValue = radio.getValue();
+        }
+
+    }
+
+    @Override
+    public void ensureDomEventHandlers(final Radio radio) {
+        final Handler handler = new Handler(radio);
+        radio.addClickHandler(handler);
+        radio.addMouseUpHandler(handler);
+        radio.addBlurHandler(handler);
+        radio.addKeyDownHandler(handler);
+    }
+
+    @Override
+    public void sinkEvents(int eventBitsToAdd, Element inputElem,
+            Element labelElem) {
+        Event.sinkEvents(inputElem,
+                eventBitsToAdd | Event.getEventsSunk(inputElem));
+        Event.sinkEvents(labelElem,
+                eventBitsToAdd | Event.getEventsSunk(labelElem));
+    }
+
+}

--- a/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/GwtBootstrap3Base.gwt.xml
+++ b/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/GwtBootstrap3Base.gwt.xml
@@ -44,6 +44,18 @@
 		<when-property-is name="user.agent" value="ie8" />
 	</replace-with>
 
+    <!-- Fall through to this rule if the browser isn't IE 8 -->
+    <replace-with class="org.gwtbootstrap3.client.ui.impl.CheckBoxImpl">
+        <when-type-is class="org.gwtbootstrap3.client.ui.impl.CheckBoxImpl" />
+    </replace-with>
+
+    <!-- IE 8 uses a different implementation -->
+    <replace-with
+        class="org.gwtbootstrap3.client.ui.impl.CheckBoxImplIE8">
+        <when-type-is class="org.gwtbootstrap3.client.ui.impl.CheckBoxImpl" />
+        <when-property-is name="user.agent" value="ie8" />
+    </replace-with>
+
 	<source path="client" />
 	<source path="shared" />
 </module>

--- a/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/GwtBootstrap3Base.gwt.xml
+++ b/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/GwtBootstrap3Base.gwt.xml
@@ -56,6 +56,18 @@
         <when-property-is name="user.agent" value="ie8" />
     </replace-with>
 
+    <!-- Fall through to this rule if the browser isn't IE 8 -->
+    <replace-with class="org.gwtbootstrap3.client.ui.impl.RadioImpl">
+        <when-type-is class="org.gwtbootstrap3.client.ui.impl.RadioImpl" />
+    </replace-with>
+
+    <!-- IE 8 uses a different implementation -->
+    <replace-with
+        class="org.gwtbootstrap3.client.ui.impl.RadioImplIE8">
+        <when-type-is class="org.gwtbootstrap3.client.ui.impl.RadioImpl" />
+        <when-property-is name="user.agent" value="ie8" />
+    </replace-with>
+
 	<source path="client" />
 	<source path="shared" />
 </module>


### PR DESCRIPTION
Just like the SimpleRadioButton and SimpleCheckBox before these implementations now use the ChangeHandler in supporting browsers instead of a ClickHandler with some additional sinkEvents/onBrowserEvents handling.