### PR TITLE
Fix that value change events are not triggered

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBoxButton.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/CheckBoxButton.java
@@ -31,10 +31,14 @@ import org.gwtbootstrap3.client.ui.constants.Styles;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.InputElement;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.i18n.client.HasDirection.Direction;
 import com.google.gwt.i18n.shared.DirectionEstimator;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
 
 /**
  * Button representing a checkbox used within a {@link ButtonGroup} that has
@@ -161,6 +165,32 @@ public class CheckBoxButton extends CheckBox implements HasActive, HasType<Butto
 
         getElement().appendChild(inputElem);
         getElement().appendChild(labelElem);
+    }
+
+    @Override
+    protected void ensureDomEventHandlers() {
+        // Use a ClickHandler since Bootstrap's jQuery does not trigger native
+        // change events:
+        // http://learn.jquery.com/events/triggering-event-handlers/
+        addClickHandler(new ClickHandler() {
+
+            @Override
+            public void onClick(ClickEvent event) {
+                ValueChangeEvent.fire(CheckBoxButton.this, getValue());
+            }
+
+        });
+    }
+
+    @Override
+    public void sinkEvents(int eventBitsToAdd) {
+        // Sink on the actual element because that's what gets clicked
+        if (isOrWasAttached()) {
+            Event.sinkEvents(getElement(),
+                    eventBitsToAdd | Event.getEventsSunk(getElement()));
+        } else {
+            super.sinkEvents(eventBitsToAdd);
+        }
     }
 
     @Override

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/RadioButton.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/RadioButton.java
@@ -31,11 +31,15 @@ import org.gwtbootstrap3.client.ui.constants.Styles;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.InputElement;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.i18n.client.HasDirection.Direction;
 import com.google.gwt.i18n.shared.DirectionEstimator;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
 
 /**
  * Button representing a radio button used within a {@link ButtonGroup} that has
@@ -192,6 +196,32 @@ public class RadioButton extends Radio implements HasActive, HasType<ButtonType>
 
         getElement().appendChild(inputElem);
         getElement().appendChild(labelElem);
+    }
+    
+    @Override
+    protected void ensureDomEventHandlers() {
+        // Use a ClickHandler since Bootstrap's jQuery does not trigger native
+        // change events:
+        // http://learn.jquery.com/events/triggering-event-handlers/
+        addClickHandler(new ClickHandler() {
+
+            @Override
+            public void onClick(ClickEvent event) {
+                ValueChangeEvent.fire(RadioButton.this, getValue());
+            }
+
+        });
+    }
+
+    @Override
+    public void sinkEvents(int eventBitsToAdd) {
+        // Sink on the actual element because that's what gets clicked
+        if (isOrWasAttached()) {
+            Event.sinkEvents(getElement(),
+                    eventBitsToAdd | Event.getEventsSunk(getElement()));
+        } else {
+            super.sinkEvents(eventBitsToAdd);
+        }
     }
 
     @Override


### PR DESCRIPTION
With my refactoring of CheckBoxButton and RadioButton the value change events were not triggered anymore because jQuery does not trigger native event listeners. Therefore I use the ClickHandler here.

Another option would be to use a jQuery listener as used in CheckableInputButton but I don't believe that JSNI is a nice solution.