### PR TITLE
Remove unnecessary compile goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
                     <executions>
                         <execution>
                             <goals>
-                                <goal>compile</goal>
                                 <goal>test</goal>
                                 <goal>resources</goal>
                             </goals>


### PR DESCRIPTION
Compile is only necessary for GWT applications not libraries.