### PR TITLE
Remove unnecessary encoding setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,6 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.9.1</version>
                         <configuration>
-                            <encoding>${project.build.sourceEncoding}</encoding>
                             <locale>en</locale>
                             <linksource>true</linksource>
                             <validateLinks>true</validateLinks>


### PR DESCRIPTION
The default value is already ${project.build.sourceEncoding}.

See http://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#encoding