### PR TITLE
Remove the GWT dependencies from parent

### DIFF
--- a/gwtbootstrap3/pom.xml
+++ b/gwtbootstrap3/pom.xml
@@ -15,6 +15,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+            <version>${gwt.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,20 +66,6 @@
         <gwt.version>2.7.0</gwt.version>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-user</artifactId>
-            <version>${gwt.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-dev</artifactId>
-            <version>${gwt.version}</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
The demo build would fail currently due to https://github.com/ArcBees/GWTP/issues/641. Therefore I removed the dependencies from the parent pom and moved them to the modules.