### PR TITLE
validateOnly and failOnError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
                                 <mode>htmlunit</mode>
                                 <testTimeOut>240</testTimeOut>
                                 <validateOnly>true</validateOnly>
+                                <failOnError>true</failOnError>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
                             <configuration>
                                 <mode>htmlunit</mode>
                                 <testTimeOut>240</testTimeOut>
+                                <validateOnly>true</validateOnly>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
With these settings we can revert #253. It will still check the source but won't compile it because it's unnecessary.