### PR TITLE
Paragraph set html

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
@@ -37,7 +37,7 @@ public class Paragraph extends HTMLPanel implements HasAlignment, HasEmphasis {
     private final HTMLMixin<Paragraph> textMixin = new HTMLMixin<Paragraph>(this);
 
     public Paragraph() {
-        super(ParagraphElement.TAG, "");
+        this("");
     }
 
     public Paragraph(final String html) {

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
@@ -41,8 +41,7 @@ public class Paragraph extends HTMLPanel implements HasAlignment, HasEmphasis {
     }
 
     public Paragraph(final String html) {
-        this();
-        setHTML(html);
+        super(ParagraphElement.TAG, html);
     }
 
     public void setText(final String text) {


### PR DESCRIPTION
This solves https://github.com/gwtbootstrap3/gwtbootstrap3-extras/issues/96 for now but not the underlying problem that setInnerHTML can't be called with just everything in IE. I will look into that.