### PR TITLE
Try jQuery.html() if setting innerHTML fails

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/HTMLMixin.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/HTMLMixin.java
@@ -20,6 +20,7 @@ package org.gwtbootstrap3.client.ui.base.mixin;
  * #L%
  */
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.UIObject;
 
 /**
@@ -36,6 +37,16 @@ public class HTMLMixin<T extends UIObject> extends TextMixin<T> {
     }
 
     public void setHTML(final String html) {
-        uiObject.getElement().setInnerHTML(html);
+        try {
+            uiObject.getElement().setInnerHTML(html);
+        } catch (Exception e) {
+            // try using jQuery.html() for handling IE, etc.
+            setInnerHTML(uiObject.getElement(), html);
+        }
     }
+
+    private native void setInnerHTML(Element e, String html) /*-{
+        $wnd.jQuery(e).html(html);
+    }-*/;
+
 }


### PR DESCRIPTION
This is a fallback for cases like https://github.com/gwtbootstrap3/gwtbootstrap3-extras/issues/96. jQuery's html() has loads of workarounds and actually works with the invalid markup currently in the demo (see https://github.com/gwtbootstrap3/gwtbootstrap3-demo/pull/58).