### PR TITLE
Basic Error Support for ValueBoxBase, InlineHelpBlock, and Icons for HelpBlock

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/HelpBlock.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/HelpBlock.java
@@ -31,20 +31,31 @@ import com.google.gwt.dom.client.Style.Unit;
 
 /**
  * @author Joshua Godi
+ * @author Steven Jardine
  */
 public class HelpBlock extends AbstractTextWidget {
+
+    private IconType iconType = null;
 
     public HelpBlock() {
         super(Document.get().createSpanElement());
         setStyleName(Styles.HELP_BLOCK);
     }
 
-    private IconType iconType = null;
-
+    /**
+     * Sets the icon type.
+     *
+     * @param type the new icon type
+     */
     public void setIconType(IconType type) {
         iconType = type;
     }
 
+    /**
+     * Gets the icon type.
+     *
+     * @return the icon type
+     */
     public IconType getIconType() {
         return iconType;
     }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/HelpBlock.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/HelpBlock.java
@@ -20,9 +20,14 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import com.google.gwt.dom.client.Document;
 import org.gwtbootstrap3.client.ui.base.AbstractTextWidget;
+import org.gwtbootstrap3.client.ui.constants.ElementTags;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.Styles;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style.Unit;
 
 /**
  * @author Joshua Godi
@@ -33,4 +38,34 @@ public class HelpBlock extends AbstractTextWidget {
         super(Document.get().createSpanElement());
         setStyleName(Styles.HELP_BLOCK);
     }
+
+    private IconType iconType = null;
+
+    public void setIconType(IconType type) {
+        iconType = type;
+    }
+
+    public IconType getIconType() {
+        return iconType;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setText(String text) {
+        super.setText(text);
+        if (iconType != null && text != null && !text.equals("")) {
+            Element e = Document.get().createElement(ElementTags.I);
+            e.addClassName(Styles.FONT_AWESOME_BASE);
+            e.addClassName(iconType.getCssName());
+            e.getStyle().setPaddingRight(5, Unit.PX);
+            getElement().insertFirst(e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getText() {
+        return super.getText();
+    }
+
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineHelpBlock.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineHelpBlock.java
@@ -25,7 +25,10 @@ import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Unit;
 
 /**
+ * Display's a help block inline.
+ * 
  * @author Joshua Godi
+ * @author Steven Jardine
  */
 public class InlineHelpBlock extends HelpBlock {
 

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineHelpBlock.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/InlineHelpBlock.java
@@ -1,0 +1,39 @@
+package org.gwtbootstrap3.client.ui;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Display;
+import com.google.gwt.dom.client.Style.Unit;
+
+/**
+ * @author Joshua Godi
+ */
+public class InlineHelpBlock extends HelpBlock {
+
+    public InlineHelpBlock() {
+        super();
+        Style style = getElement().getStyle();
+        style.setDisplay(Display.INLINE_BLOCK);
+        style.setPaddingLeft(10, Unit.PX);
+    }
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
@@ -20,25 +20,29 @@ package org.gwtbootstrap3.client.ui.base;
  * #L%
  */
 
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.text.shared.Parser;
-import com.google.gwt.text.shared.Renderer;
+import java.util.List;
 
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
 import org.gwtbootstrap3.client.ui.base.mixin.IdMixin;
 import org.gwtbootstrap3.client.ui.constants.DeviceSize;
 import org.gwtbootstrap3.client.ui.constants.InputSize;
 
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.editor.client.EditorError;
+import com.google.gwt.editor.client.HasEditorErrors;
+import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.text.shared.Parser;
+import com.google.gwt.text.shared.Renderer;
+
 public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<T> implements HasId, HasResponsiveness,
-        HasPlaceholder, HasAutoComplete, HasSize<InputSize> {
+        HasPlaceholder, HasAutoComplete, HasSize<InputSize>, HasEditorErrors<T> {
 
     private static final String MAX_LENGTH = "maxlength";
 
     private final IdMixin<ValueBoxBase<T>> idMixin = new IdMixin<ValueBoxBase<T>>(this);
 
     /**
-     * Creates a value box that wraps the given browser element handle. This is
-     * only used by subclasses.
+     * Creates a value box that wraps the given browser element handle. This is only used by subclasses.
      *
      * @param elem the browser element to wrap
      */
@@ -99,4 +103,42 @@ public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<
     public InputSize getSize() {
         return InputSize.fromStyleName(getStyleName());
     }
+    
+    public interface EditorErrorSupport extends AttachEvent.Handler {
+        
+        void showErrors(List<EditorError> errors);
+
+    }
+    
+    private EditorErrorSupport errorSupport = new ValueBoxErrorSupport(this);
+
+    public void setAddErrorSupport(boolean addErrorSupport) {
+        if (!addErrorSupport) {
+            errorSupport = null;
+        }
+    }
+    
+    public boolean getAddErrorSupport() {
+        return errorSupport !=  null;
+    }
+    
+    public void setErrorSupport(EditorErrorSupport errorSupport) {
+        this.errorSupport = errorSupport;
+        addAttachHandler(errorSupport);
+    }
+   
+    @Override
+    public void showErrors(List<EditorError> errors) {
+        if (errorSupport != null) {
+            errorSupport.showErrors(errors);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setValue(T value, boolean fireEvents) {
+        showErrors(null);
+        super.setValue(value, fireEvents);
+    }
+
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
@@ -37,9 +37,20 @@ import com.google.gwt.text.shared.Renderer;
 public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<T> implements HasId, HasResponsiveness,
         HasPlaceholder, HasAutoComplete, HasSize<InputSize>, HasEditorErrors<T> {
 
+    /**
+     * Add support for HasEditorErrors implementation.
+     */
+    public interface EditorErrorSupport extends AttachEvent.Handler {
+        
+        void showErrors(List<EditorError> errors);
+
+    }
+
     private static final String MAX_LENGTH = "maxlength";
 
     private final IdMixin<ValueBoxBase<T>> idMixin = new IdMixin<ValueBoxBase<T>>(this);
+
+    private EditorErrorSupport errorSupport = new ValueBoxErrorSupport(this);
 
     /**
      * Creates a value box that wraps the given browser element handle. This is only used by subclasses.
@@ -104,14 +115,6 @@ public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<
         return InputSize.fromStyleName(getStyleName());
     }
     
-    public interface EditorErrorSupport extends AttachEvent.Handler {
-        
-        void showErrors(List<EditorError> errors);
-
-    }
-    
-    private EditorErrorSupport errorSupport = new ValueBoxErrorSupport(this);
-
     public void setAddErrorSupport(boolean addErrorSupport) {
         if (!addErrorSupport) {
             errorSupport = null;

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxErrorSupport.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxErrorSupport.java
@@ -1,0 +1,104 @@
+package org.gwtbootstrap3.client.ui.base;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+import org.gwtbootstrap3.client.ui.HelpBlock;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+
+import com.google.gwt.editor.client.EditorError;
+import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.gwt.user.client.ui.Widget;
+
+public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
+
+    private final Widget inputWidget;
+
+    private HelpBlock validationStateHelpBlock = null;
+
+    private HasValidationState validationStateParent = null;
+
+    private boolean initialized = false;
+
+    public ValueBoxErrorSupport(Widget widget) {
+        super();
+        assert widget != null;
+        inputWidget = widget;
+    }
+
+    private HelpBlock findHelpBlock(Widget widget) {
+        if (widget instanceof HelpBlock) return (HelpBlock) widget;
+        // Try and find the HelpBlock in the children of the given widget.
+        if (widget instanceof HasWidgets) {
+            for (Widget w : (HasWidgets) widget) {
+                if (w instanceof HelpBlock) return (HelpBlock) w;
+            }
+        }
+        if (!(widget instanceof HasValidationState)) {
+            // Try and find the HelpBlock in the parent of widget.
+            return findHelpBlock(widget.getParent());
+        }
+        return null;
+    }
+
+    public void init() {
+        if (initialized) return;
+        initialized = true;
+        Widget parent = inputWidget.getParent();
+        while (parent != null && !parent.getClass().getName().equals("com.google.gwt.user.client.ui.Widget")) {
+            if (parent instanceof HasValidationState) {
+                validationStateParent = (HasValidationState) parent;
+                validationStateHelpBlock = findHelpBlock(inputWidget);
+            }
+            parent = parent.getParent();
+        }
+    }
+
+    @Override
+    public void onAttachOrDetach(AttachEvent event) {
+        if (event.isAttached()) {
+            init();
+        }
+    }
+
+    @Override
+    public void showErrors(List<EditorError> errors) {
+        init();
+        String errorMsg = "";
+        if (validationStateParent != null) {
+            if (errors == null) {
+                validationStateParent.setValidationState(ValidationState.NONE);
+            } else {
+                validationStateParent.setValidationState(errors.size() <= 0 ? ValidationState.SUCCESS : ValidationState.ERROR);
+                for (int index = 0; index < errors.size(); index++) {
+                    errorMsg = errors.get(0).getMessage();
+                    if (index + 1 < errors.size()) errorMsg += "; ";
+                }
+            }
+        }
+        if (validationStateHelpBlock != null) {
+            validationStateHelpBlock.setText(errorMsg);
+        }
+    }
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxErrorSupport.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxErrorSupport.java
@@ -1,6 +1,7 @@
 package org.gwtbootstrap3.client.ui.base;
 
 /*
+/*
  * #%L
  * GwtBootstrap3
  * %%
@@ -23,6 +24,7 @@ package org.gwtbootstrap3.client.ui.base;
 import java.util.List;
 
 import org.gwtbootstrap3.client.ui.HelpBlock;
+import org.gwtbootstrap3.client.ui.base.ValueBoxBase.EditorErrorSupport;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 
 import com.google.gwt.editor.client.EditorError;
@@ -30,6 +32,22 @@ import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.Widget;
 
+/**
+ * This is the default {@link EditorErrorSupport} implementation. The assumption is that every
+ * {@link ValueBoxBase} instance will have a {@link HasValidationState} parent. If there is a
+ * {@link HelpBlock} that is a child of the {@link HasValidationState} parent then error messages will be
+ * displayed in the {@link HelpBlock}.
+ * 
+ * Example:
+ * 
+ * <b:FormGroup>
+ *   <b:FormLabel for="username">User</b:FormLabel>
+ *   <b:TextBox b:id="username" ui:field="username" /> 
+ *   <b:HelpBlock iconType="EXCLAMATION" /> 
+ * </b:FormGroup>
+ * 
+ * @author Steven Jardine
+ */
 public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
 
     private final Widget inputWidget;
@@ -46,6 +64,12 @@ public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
         inputWidget = widget;
     }
 
+    /**
+     * Find the sibling {@link HelpBlock}.
+     *
+     * @param widget the {@link Widget} to search.
+     * @return the found {@link HelpBlock} of null if not found.
+     */
     private HelpBlock findHelpBlock(Widget widget) {
         if (widget instanceof HelpBlock) return (HelpBlock) widget;
         // Try and find the HelpBlock in the children of the given widget.
@@ -61,6 +85,10 @@ public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
         return null;
     }
 
+    /**
+     * Initialize the instance. We find the parent {@link HasValidationState} and sibling {@link HelpBlock}
+     * only 1 time on initialization.
+     */
     public void init() {
         if (initialized) return;
         initialized = true;
@@ -74,6 +102,7 @@ public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void onAttachOrDetach(AttachEvent event) {
         if (event.isAttached()) {
@@ -81,6 +110,7 @@ public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void showErrors(List<EditorError> errors) {
         init();


### PR DESCRIPTION
Added an InlineHelpBlock.
Added IconType for HelpBlock which added an icon at the beginning of the HelpBlock text.
Added basic error support for ValueBoxBase.  This assumes the input has a HasValidationState parent.  Error messages won't be displayed unless the HasValidationState parent has a HelpBlock child.

![screenshot from 2015-02-02 13 08 03](https://cloud.githubusercontent.com/assets/370017/6008262/7baec93e-aadd-11e4-929d-533a843694a5.png)
