### PR TITLE
Fix default Collapse behavior / Add Form constructor

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Collapse.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Collapse.java
@@ -49,7 +49,9 @@ public class Collapse extends Div {
         bindJavaScriptEvents(getElement());
 
         // Configure the collapse
-        collapse(getElement(), toggle);
+        if(toggle) {
+            addStyleName("in");
+        }
     }
 
     @Override

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Form.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Form.java
@@ -20,6 +20,7 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
+import com.google.gwt.uibinder.client.UiConstructor;
 import org.gwtbootstrap3.client.ui.base.HasType;
 import org.gwtbootstrap3.client.ui.base.form.AbstractForm;
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
@@ -35,6 +36,15 @@ import org.gwtbootstrap3.client.ui.constants.FormType;
  * @see Legend
  */
 public class Form extends AbstractForm implements HasType<FormType> {
+
+    public Form() {
+    }
+
+    @UiConstructor
+    public Form(final FormType type) {
+      this();
+      setType(type);
+    }
 
     @Override
     public void setType(final FormType type) {

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Form.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Form.java
@@ -38,12 +38,12 @@ import org.gwtbootstrap3.client.ui.constants.FormType;
 public class Form extends AbstractForm implements HasType<FormType> {
 
     public Form() {
+        this(FormType.DEFAULT);
     }
 
     @UiConstructor
     public Form(final FormType type) {
-      this();
-      setType(type);
+        setType(type);
     }
 
     @Override


### PR DESCRIPTION
If you use a Collapse with toggle = true when it is loaded it should not animate the expansion.

In the onLoad() method there is a call to:
```java
collapse(getElement(), toggle);
```
We should change to:
```java
if (this.toggle) {
    addStyleNames("in");
}
```
This way the element will be presented already expanded. In case the user wants it to be animated, he should call ```show()```.

Here is a demo of plain bootstrap behaviour: http://jsfiddle.net/uf61hdv2/1/