### PR TITLE
Fix a bug introduced in PR #299 where the default constructor has been r...

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Form.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Form.java
@@ -20,7 +20,6 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import com.google.gwt.uibinder.client.UiConstructor;
 import org.gwtbootstrap3.client.ui.base.HasType;
 import org.gwtbootstrap3.client.ui.base.form.AbstractForm;
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
@@ -41,7 +40,6 @@ public class Form extends AbstractForm implements HasType<FormType> {
         this(FormType.DEFAULT);
     }
 
-    @UiConstructor
     public Form(final FormType type) {
         setType(type);
     }


### PR DESCRIPTION
I introduced a bug in the Form caused by @ UiConstructor annotation. UiBinder uses only the default constructor or the constructor annotated @UiConstructor. I found this bug with a internal testcase.