### PR TITLE
Minor refactoring of JSR-303 bean validation.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/SuggestBox.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/SuggestBox.java
@@ -29,14 +29,16 @@ import org.gwtbootstrap3.client.ui.base.HasPlaceholder;
 import org.gwtbootstrap3.client.ui.base.HasResponsiveness;
 import org.gwtbootstrap3.client.ui.base.HasSize;
 import org.gwtbootstrap3.client.ui.base.ValueBoxBase;
-import org.gwtbootstrap3.client.ui.base.ValueBoxBase.EditorErrorSupport;
-import org.gwtbootstrap3.client.ui.base.ValueBoxErrorSupport;
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
 import org.gwtbootstrap3.client.ui.base.mixin.EnabledMixin;
+import org.gwtbootstrap3.client.ui.base.mixin.ErrorHandlerMixin;
 import org.gwtbootstrap3.client.ui.base.mixin.IdMixin;
 import org.gwtbootstrap3.client.ui.constants.DeviceSize;
 import org.gwtbootstrap3.client.ui.constants.InputSize;
 import org.gwtbootstrap3.client.ui.constants.Styles;
+import org.gwtbootstrap3.client.ui.form.error.ErrorHandler;
+import org.gwtbootstrap3.client.ui.form.error.ErrorHandlerType;
+import org.gwtbootstrap3.client.ui.form.error.HasErrorHandler;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -73,7 +75,7 @@ import com.google.gwt.user.client.ui.SuggestOracle.Suggestion;
  * @author Steven Jardine
  */
 public class SuggestBox extends com.google.gwt.user.client.ui.SuggestBox implements HasId, HasResponsiveness, HasPlaceholder,
-        HasAutoComplete, HasSize<InputSize>, HasEditorErrors<String> {
+        HasAutoComplete, HasSize<InputSize>, HasEditorErrors<String>, HasErrorHandler {
 
     static class CustomSuggestionDisplay extends DefaultSuggestionDisplay {
 
@@ -132,7 +134,7 @@ public class SuggestBox extends com.google.gwt.user.client.ui.SuggestBox impleme
 
     private final EnabledMixin<SuggestBox> enabledMixin = new EnabledMixin<SuggestBox>(this);
 
-    private EditorErrorSupport errorSupport = new ValueBoxErrorSupport(this);
+    private final ErrorHandlerMixin<SuggestBox, String> errorHandlerMixin = new ErrorHandlerMixin<SuggestBox, String>(this);
 
     private final IdMixin<SuggestBox> idMixin = new IdMixin<SuggestBox>(this);
 
@@ -177,19 +179,22 @@ public class SuggestBox extends com.google.gwt.user.client.ui.SuggestBox impleme
         setStyleName(Styles.FORM_CONTROL);
     }
 
-    /**
-     * Gets the error support.
-     *
-     * @return the adds the error support
-     */
-    public boolean getAddErrorSupport() {
-        return errorSupport != null;
-    }
-
     /** {@inheritDoc} */
     @Override
     public String getAutoComplete() {
         return getElement().getAttribute(AUTO_COMPLETE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return errorHandlerMixin.getErrorHandler();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ErrorHandlerType getErrorHandlerType() {
+        return errorHandlerMixin.getErrorHandlerType();
     }
 
     /**
@@ -218,17 +223,6 @@ public class SuggestBox extends com.google.gwt.user.client.ui.SuggestBox impleme
         return enabledMixin.isEnabled();
     }
 
-    /**
-     * Sets the error support.
-     *
-     * @param addErrorSupport the new adds the error support
-     */
-    public void setAddErrorSupport(final boolean addErrorSupport) {
-        if (!addErrorSupport) {
-            errorSupport = null;
-        }
-    }
-
     /** {@inheritDoc} */
     @Override
     public void setAutoComplete(final boolean autoComplete) {
@@ -241,12 +235,16 @@ public class SuggestBox extends com.google.gwt.user.client.ui.SuggestBox impleme
         enabledMixin.setEnabled(enabled);
     }
 
-    /**
-     * @param errorSupport the EditorErrorSupport to set.
-     */
-    public void setErrorSupport(final EditorErrorSupport errorSupport) {
-        this.errorSupport = errorSupport;
-        addAttachHandler(errorSupport);
+    /** {@inheritDoc} */
+    @Override
+    public void setErrorHandler(ErrorHandler handler) {
+        errorHandlerMixin.setErrorHandler(handler);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setErrorHandlerType(ErrorHandlerType type) {
+        errorHandlerMixin.setErrorHandlerType(type);
     }
 
     /** {@inheritDoc} */
@@ -279,11 +277,10 @@ public class SuggestBox extends com.google.gwt.user.client.ui.SuggestBox impleme
         StyleHelper.setVisibleOn(this, deviceSize);
     }
 
+    /** {@inheritDoc} */
     @Override
-    public void showErrors(final List<EditorError> errors) {
-        if (errorSupport != null) {
-            errorSupport.showErrors(errors);
-        }
+    public void showErrors(List<EditorError> errors) {
+        errorHandlerMixin.showErrors(errors);
     }
 
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
@@ -23,34 +23,28 @@ package org.gwtbootstrap3.client.ui.base;
 import java.util.List;
 
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
+import org.gwtbootstrap3.client.ui.base.mixin.ErrorHandlerMixin;
 import org.gwtbootstrap3.client.ui.base.mixin.IdMixin;
 import org.gwtbootstrap3.client.ui.constants.DeviceSize;
 import org.gwtbootstrap3.client.ui.constants.InputSize;
+import org.gwtbootstrap3.client.ui.form.error.ErrorHandler;
+import org.gwtbootstrap3.client.ui.form.error.ErrorHandlerType;
+import org.gwtbootstrap3.client.ui.form.error.HasErrorHandler;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.editor.client.EditorError;
 import com.google.gwt.editor.client.HasEditorErrors;
-import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.text.shared.Parser;
 import com.google.gwt.text.shared.Renderer;
 
 public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<T> implements HasId, HasResponsiveness,
-        HasPlaceholder, HasAutoComplete, HasSize<InputSize>, HasEditorErrors<T> {
-
-    /**
-     * Add support for HasEditorErrors implementation.
-     */
-    public interface EditorErrorSupport extends AttachEvent.Handler {
-        
-        void showErrors(List<EditorError> errors);
-
-    }
+        HasPlaceholder, HasAutoComplete, HasSize<InputSize>, HasEditorErrors<T>, HasErrorHandler {
 
     private static final String MAX_LENGTH = "maxlength";
 
     private final IdMixin<ValueBoxBase<T>> idMixin = new IdMixin<ValueBoxBase<T>>(this);
 
-    private EditorErrorSupport errorSupport = new ValueBoxErrorSupport(this);
+    private final ErrorHandlerMixin<ValueBoxBase<T>, T> errorHandlerMixin = new ErrorHandlerMixin<ValueBoxBase<T>, T>(this);
 
     /**
      * Creates a value box that wraps the given browser element handle. This is only used by subclasses.
@@ -114,34 +108,42 @@ public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<
     public InputSize getSize() {
         return InputSize.fromStyleName(getStyleName());
     }
-    
-    public void setAddErrorSupport(boolean addErrorSupport) {
-        if (!addErrorSupport) {
-            errorSupport = null;
-        }
-    }
-    
-    public boolean getAddErrorSupport() {
-        return errorSupport !=  null;
-    }
-    
-    public void setErrorSupport(EditorErrorSupport errorSupport) {
-        this.errorSupport = errorSupport;
-        addAttachHandler(errorSupport);
-    }
-   
-    @Override
-    public void showErrors(List<EditorError> errors) {
-        if (errorSupport != null) {
-            errorSupport.showErrors(errors);
-        }
-    }
 
     /** {@inheritDoc} */
     @Override
     public void setValue(T value, boolean fireEvents) {
         showErrors(null);
         super.setValue(value, fireEvents);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void showErrors(List<EditorError> errors) {
+        errorHandlerMixin.showErrors(errors);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return errorHandlerMixin.getErrorHandler();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setErrorHandler(ErrorHandler handler) {
+        errorHandlerMixin.setErrorHandler(handler);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ErrorHandlerType getErrorHandlerType() {
+        return errorHandlerMixin.getErrorHandlerType();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setErrorHandlerType(ErrorHandlerType type) {
+        errorHandlerMixin.setErrorHandlerType(type);
     }
 
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/ValueBoxBase.java
@@ -112,7 +112,7 @@ public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<
     /** {@inheritDoc} */
     @Override
     public void setValue(T value, boolean fireEvents) {
-        showErrors(null);
+        errorHandlerMixin.clearErrors();
         super.setValue(value, fireEvents);
     }
 

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/ErrorHandlerMixin.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/ErrorHandlerMixin.java
@@ -1,5 +1,25 @@
 package org.gwtbootstrap3.client.ui.base.mixin;
 
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.gwtbootstrap3.client.ui.form.error.DefaultErrorHandler;

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/ErrorHandlerMixin.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/ErrorHandlerMixin.java
@@ -1,0 +1,86 @@
+package org.gwtbootstrap3.client.ui.base.mixin;
+
+import java.util.List;
+
+import org.gwtbootstrap3.client.ui.form.error.DefaultErrorHandler;
+import org.gwtbootstrap3.client.ui.form.error.ErrorHandler;
+import org.gwtbootstrap3.client.ui.form.error.ErrorHandlerType;
+import org.gwtbootstrap3.client.ui.form.error.HasErrorHandler;
+
+import com.google.gwt.editor.client.EditorError;
+import com.google.gwt.editor.client.HasEditorErrors;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Mixin to handle error handler support.
+ *
+ * @param <T> the type of input widget.
+ * @param <V> the type of editor value.
+ */
+public class ErrorHandlerMixin<T extends Widget & HasEditorErrors<V> & HasErrorHandler, V> implements HasEditorErrors<V>,
+        HasErrorHandler {
+
+    private ErrorHandler errorHandler;
+
+    private ErrorHandlerType errorHandlerType = ErrorHandlerType.DEFAULT;
+
+    private Widget inputWidget = null;
+
+    /**
+     * Mixin for the {@link ErrorHandler} implementation.
+     *
+     * @param widget the widget
+     */
+    public ErrorHandlerMixin(Widget widget) {
+        inputWidget = widget;
+        errorHandler = new DefaultErrorHandler(inputWidget);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ErrorHandlerType getErrorHandlerType() {
+        return errorHandlerType;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setErrorHandler(ErrorHandler handler) {
+        errorHandlerType = null;
+        errorHandler = handler;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setErrorHandlerType(ErrorHandlerType type) {
+        if (errorHandler != null) {
+            errorHandler.cleanup();
+        }
+        errorHandlerType = type == null ? ErrorHandlerType.DEFAULT : type;
+        switch (errorHandlerType) {
+        case NONE:
+            errorHandler = null;
+            break;
+        case DEFAULT:
+            errorHandler = new DefaultErrorHandler(inputWidget);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void showErrors(List<EditorError> errors) {
+        if (errorHandler != null) {
+            if (errors == null || errors.isEmpty()) {
+                errorHandler.clearErrors();
+                return;
+            }
+            errorHandler.showErrors(errors);
+        }
+    }
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/ErrorHandlerMixin.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/ErrorHandlerMixin.java
@@ -56,6 +56,15 @@ public class ErrorHandlerMixin<T extends Widget & HasEditorErrors<V> & HasErrorH
         errorHandler = new DefaultErrorHandler(inputWidget);
     }
 
+    /**
+     * Clear the errors.
+     */
+    public void clearErrors() {
+        if (errorHandler != null) {
+            errorHandler.clearErrors();
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public ErrorHandler getErrorHandler() {

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/DefaultErrorHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/DefaultErrorHandler.java
@@ -1,5 +1,25 @@
 package org.gwtbootstrap3.client.ui.form.error;
 
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.gwtbootstrap3.client.ui.HelpBlock;

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/DefaultErrorHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/DefaultErrorHandler.java
@@ -1,39 +1,20 @@
-package org.gwtbootstrap3.client.ui.base;
-
-/*
-/*
- * #%L
- * GwtBootstrap3
- * %%
- * Copyright (C) 2013 GwtBootstrap3
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
+package org.gwtbootstrap3.client.ui.form.error;
 
 import java.util.List;
 
 import org.gwtbootstrap3.client.ui.HelpBlock;
-import org.gwtbootstrap3.client.ui.base.ValueBoxBase.EditorErrorSupport;
+import org.gwtbootstrap3.client.ui.base.HasValidationState;
+import org.gwtbootstrap3.client.ui.base.ValueBoxBase;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 
 import com.google.gwt.editor.client.EditorError;
 import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.event.logical.shared.AttachEvent.Handler;
 import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.Widget;
 
 /**
- * This is the default {@link EditorErrorSupport} implementation. The assumption is that every
+ * This is the default {@link ErrorHandler} implementation. The assumption is that every
  * {@link ValueBoxBase} instance will have a {@link HasValidationState} parent. If there is a
  * {@link HelpBlock} that is a child of the {@link HasValidationState} parent then error messages will be
  * displayed in the {@link HelpBlock}.
@@ -48,7 +29,9 @@ import com.google.gwt.user.client.ui.Widget;
  * 
  * @author Steven Jardine
  */
-public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
+public class DefaultErrorHandler implements ErrorHandler {
+
+    private boolean initialized = false;
 
     private final Widget inputWidget;
 
@@ -56,12 +39,34 @@ public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
 
     private HasValidationState validationStateParent = null;
 
-    private boolean initialized = false;
-
-    public ValueBoxErrorSupport(Widget widget) {
+    /**
+     * Default error handler.
+     *
+     * @param parent the parent of this error handler.
+     */
+    public DefaultErrorHandler(Widget widget) {
         super();
         assert widget != null;
-        inputWidget = widget;
+        this.inputWidget = widget;
+        this.inputWidget.addAttachHandler(new Handler() {
+            @Override
+            public void onAttachOrDetach(AttachEvent event) {
+                init();
+            }
+        });
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void cleanup() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void clearErrors() {
+        if (validationStateParent == null) { return; }
+        validationStateParent.setValidationState(ValidationState.NONE);
+        if (validationStateHelpBlock != null) validationStateHelpBlock.setText("");
     }
 
     /**
@@ -104,26 +109,15 @@ public class ValueBoxErrorSupport implements ValueBoxBase.EditorErrorSupport {
 
     /** {@inheritDoc} */
     @Override
-    public void onAttachOrDetach(AttachEvent event) {
-        if (event.isAttached()) {
-            init();
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void showErrors(List<EditorError> errors) {
         init();
+        clearErrors();
         String errorMsg = "";
         if (validationStateParent != null) {
-            if (errors == null) {
-                validationStateParent.setValidationState(ValidationState.NONE);
-            } else {
-                validationStateParent.setValidationState(errors.size() <= 0 ? ValidationState.SUCCESS : ValidationState.ERROR);
-                for (int index = 0; index < errors.size(); index++) {
-                    errorMsg = errors.get(0).getMessage();
-                    if (index + 1 < errors.size()) errorMsg += "; ";
-                }
+            validationStateParent.setValidationState(errors.size() <= 0 ? ValidationState.NONE : ValidationState.ERROR);
+            for (int index = 0; index < errors.size(); index++) {
+                errorMsg = errors.get(0).getMessage();
+                if (index + 1 < errors.size()) errorMsg += "; ";
             }
         }
         if (validationStateHelpBlock != null) {

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/DefaultErrorHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/DefaultErrorHandler.java
@@ -131,7 +131,7 @@ public class DefaultErrorHandler implements ErrorHandler {
     @Override
     public void showErrors(List<EditorError> errors) {
         init();
-        clearErrors();
+        //clearErrors();
         String errorMsg = "";
         if (validationStateParent != null) {
             validationStateParent.setValidationState(errors.size() <= 0 ? ValidationState.NONE : ValidationState.ERROR);

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandler.java
@@ -8,7 +8,7 @@ import com.google.gwt.editor.client.EditorError;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 - 2015 GwtBootstrap3
+ * Copyright (C) 2015 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandler.java
@@ -1,0 +1,51 @@
+package org.gwtbootstrap3.client.ui.form.error;
+
+import java.util.List;
+
+import com.google.gwt.editor.client.EditorError;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Error handler.
+ * 
+ * @author Steven Jardine
+ */
+public interface ErrorHandler {
+
+    /**
+     * Clean up the handler if necessary.
+     */
+    void cleanup();
+
+    /**
+     * Clear any errors.
+     */
+    void clearErrors();
+
+    /**
+     * Show the errors on the input screen.
+     * 
+     * @param errors the errors to display.
+     */
+    void showErrors(List<EditorError> errors);
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandlerType.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandlerType.java
@@ -1,5 +1,28 @@
 package org.gwtbootstrap3.client.ui.form.error;
 
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * The type of error handler to use.
+ */
 public enum ErrorHandlerType {
 
     NONE,

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandlerType.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/ErrorHandlerType.java
@@ -1,0 +1,8 @@
+package org.gwtbootstrap3.client.ui.form.error;
+
+public enum ErrorHandlerType {
+
+    NONE,
+    DEFAULT,
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/HasErrorHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/HasErrorHandler.java
@@ -1,13 +1,58 @@
 package org.gwtbootstrap3.client.ui.form.error;
 
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Has an error handler.
+ * 
+ * @author Steven Jardine
+ */
 public interface HasErrorHandler {
 
+    /**
+     * Gets the error handler.
+     *
+     * @return the error handler
+     */
     ErrorHandler getErrorHandler();
 
+    /**
+     * Sets the error handler.
+     *
+     * @param errorHandler the new error handler
+     */
     void setErrorHandler(ErrorHandler errorHandler);
 
+    /**
+     * Gets the error handler type.
+     *
+     * @return the error handler type
+     */
     ErrorHandlerType getErrorHandlerType();
 
+    /**
+     * Sets the error handler type.
+     *
+     * @param errorHandlerType the new error handler type
+     */
     void setErrorHandlerType(ErrorHandlerType errorHandlerType);
 
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/HasErrorHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/HasErrorHandler.java
@@ -1,0 +1,13 @@
+package org.gwtbootstrap3.client.ui.form.error;
+
+public interface HasErrorHandler {
+
+    ErrorHandler getErrorHandler();
+
+    void setErrorHandler(ErrorHandler errorHandler);
+
+    ErrorHandlerType getErrorHandlerType();
+
+    void setErrorHandlerType(ErrorHandlerType errorHandlerType);
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/package-info.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/package-info.java
@@ -1,15 +1,21 @@
-/**
- * MJN SERVICES, INC. CONFIDENTIAL
- * $Id$
- * Copyright (c) 2015 MJN Services, Inc., All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains the property of MJN Services, Inc. and its suppliers,
- * if any.  The intellectual and technical concepts contained herein are proprietary to MJN Services, Inc. and its
- * suppliers and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret
- * or copyright law. Dissemination or use of this information or reproduction of this material is strictly forbidden
- * unless prior written permission is obtained from MJN Services, Inc.
- */
-/**
- * @author "Steven Jardine <steve@mjnservices.com>"
- */
 package org.gwtbootstrap3.client.ui.form.error;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/package-info.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/error/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * MJN SERVICES, INC. CONFIDENTIAL
+ * $Id$
+ * Copyright (c) 2015 MJN Services, Inc., All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains the property of MJN Services, Inc. and its suppliers,
+ * if any.  The intellectual and technical concepts contained herein are proprietary to MJN Services, Inc. and its
+ * suppliers and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret
+ * or copyright law. Dissemination or use of this information or reproduction of this material is strictly forbidden
+ * unless prior written permission is obtained from MJN Services, Inc.
+ */
+/**
+ * @author "Steven Jardine <steve@mjnservices.com>"
+ */
+package org.gwtbootstrap3.client.ui.form.error;


### PR DESCRIPTION
These changes are in preparation for additional error handlers (possibly based on popover and tooltip).  I also added a ErrorHandlerMixin that encapsulates common error handling code.

Error handlers can be specified in uibinder with errorHandlerType.  Currently only NONE or DEFAULT.

No changes to the demo are necessary.