### PR TITLE
Added required star to FormLabel.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
@@ -4,7 +4,7 @@ package org.gwtbootstrap3.client.ui;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 GwtBootstrap3
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,79 @@ package org.gwtbootstrap3.client.ui;
 
 import org.gwtbootstrap3.client.ui.base.AbstractTextWidget;
 import org.gwtbootstrap3.client.ui.constants.Attributes;
+import org.gwtbootstrap3.client.ui.constants.ElementTags;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.Styles;
 
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.DomEvent;
 
 /**
  * @author Sven Jacobs
+ * @author Steven Jardine
  */
 public class FormLabel extends AbstractTextWidget {
 
+    private Element iconElement = null;
+
+    private boolean required = false;
+
+    /**
+     * Constructor.
+     */
     public FormLabel() {
         super(Document.get().createLabelElement());
         setStyleName(Styles.CONTROL_LABEL);
+        addHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event) {
+                String html = getHTML();
+                if (!required || html == null || "".equals(html)) {
+                    if (iconElement != null) {
+                        iconElement.removeFromParent();
+                    }
+                } else {
+                    if (iconElement == null) {
+                        iconElement = createIconElement();
+                    }
+                    getElement().appendChild(iconElement);
+                }
+            }
+        }, ChangeEvent.getType());
+    }
+
+    /**
+     * @return a new icon element. We only create this when {@link #iconElement} is null or the
+     *         {@link #required} has changed.
+     */
+    protected Element createIconElement() {
+        Element e = Document.get().createElement(ElementTags.I);
+        e.addClassName(Styles.FONT_AWESOME_BASE);
+        e.addClassName(IconType.STAR.getCssName());
+        e.addClassName(Styles.HAS_ERROR);
+        Style s = e.getStyle();
+        s.setFontSize(6, Unit.PX);
+        s.setPaddingLeft(2, Unit.PX);
+        s.setPaddingRight(5, Unit.PX);
+        s.setColor("#b94a48");
+
+        Element sup = Document.get().createElement("sup");
+        sup.addClassName(Styles.HAS_ERROR);
+        sup.appendChild(e);
+
+        return sup;
+    }
+
+    /**
+     * @return does this label show required?
+     */
+    public boolean getRequired() {
+        return required;
     }
 
     public void setFor(final String f) {
@@ -43,4 +104,27 @@ public class FormLabel extends AbstractTextWidget {
             getElement().removeAttribute(Attributes.FOR);
         }
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setHTML(final String html) {
+        super.setHTML(html);
+        DomEvent.fireNativeEvent(Document.get().createChangeEvent(), this);
+    }
+
+    /**
+     * @param should this label show as required?
+     */
+    public void setRequired(boolean required) {
+        this.required = required;
+        DomEvent.fireNativeEvent(Document.get().createChangeEvent(), this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setText(String text) {
+        super.setText(text);
+        DomEvent.fireNativeEvent(Document.get().createChangeEvent(), this);
+    }
+
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
@@ -76,17 +76,13 @@ public class FormLabel extends AbstractTextWidget {
         Element e = Document.get().createElement(ElementTags.I);
         e.addClassName(Styles.FONT_AWESOME_BASE);
         e.addClassName(IconType.STAR.getCssName());
-        e.addClassName(Styles.HAS_ERROR);
         Style s = e.getStyle();
         s.setFontSize(6, Unit.PX);
         s.setPaddingLeft(2, Unit.PX);
         s.setPaddingRight(5, Unit.PX);
         s.setColor("#b94a48");
-
         Element sup = Document.get().createElement("sup");
-        sup.addClassName(Styles.HAS_ERROR);
         sup.appendChild(e);
-
         return sup;
     }
 

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
@@ -42,7 +42,7 @@ public class FormLabel extends AbstractTextWidget {
 
     private Element iconElement = null;
 
-    private boolean required = false;
+    private boolean showRequiredIndicator = false;
 
     /**
      * Constructor.
@@ -54,7 +54,7 @@ public class FormLabel extends AbstractTextWidget {
             @Override
             public void onChange(ChangeEvent event) {
                 String html = getHTML();
-                if (!required || html == null || "".equals(html)) {
+                if (!showRequiredIndicator || html == null || "".equals(html)) {
                     if (iconElement != null) {
                         iconElement.removeFromParent();
                     }
@@ -70,7 +70,7 @@ public class FormLabel extends AbstractTextWidget {
 
     /**
      * @return a new icon element. We only create this when {@link #iconElement} is null or the
-     *         {@link #required} has changed.
+     *         {@link #showRequiredIndicator} has changed.
      */
     protected Element createIconElement() {
         Element e = Document.get().createElement(ElementTags.I);
@@ -89,8 +89,8 @@ public class FormLabel extends AbstractTextWidget {
     /**
      * @return does this label show required?
      */
-    public boolean getRequired() {
-        return required;
+    public boolean getShowRequiredIndicator() {
+        return showRequiredIndicator;
     }
 
     public void setFor(final String f) {
@@ -111,8 +111,8 @@ public class FormLabel extends AbstractTextWidget {
     /**
      * @param should this label show as required?
      */
-    public void setRequired(boolean required) {
-        this.required = required;
+    public void setShowRequiredIndicator(boolean required) {
+        this.showRequiredIndicator = required;
         DomEvent.fireNativeEvent(Document.get().createChangeEvent(), this);
     }
 


### PR DESCRIPTION
I think this is a good feature but will understand if it is not wanted.  When the "required" field is specified in uibinder then a star icon is displayed following the label.

I like the way the icon is added better than the HelpBlock implementation but it is a more complicated implementation.

Here is a screenshot:
![requiredstar](https://cloud.githubusercontent.com/assets/370017/6179948/c6f5e624-b2db-11e4-8131-bf61b5a1b2be.png)

Let me know what you think.
