### PR TITLE
Resolves #314. Resolves #315.  Add check for bootstrap3 prior to injecting.  Fixes NPE in HelpBlock.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3EntryPoint.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3EntryPoint.java
@@ -4,7 +4,7 @@ package org.gwtbootstrap3.client;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 GwtBootstrap3
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,22 +24,21 @@ import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.ScriptInjector;
 
 /**
+ * Provides script injection for jQuery and boostrap if they aren't already loaded.
+ * 
  * @author Sven Jacobs
+ * @author Steven Jardine
  */
 public class GwtBootstrap3EntryPoint implements EntryPoint {
 
-    @Override
-    public void onModuleLoad() {
-        if (!isjQueryLoaded()) {
-            ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.jQuery().getText())
-                    .setWindow(ScriptInjector.TOP_WINDOW)
-                    .inject();
-        }
-
-        ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.bootstrap().getText())
-                .setWindow(ScriptInjector.TOP_WINDOW)
-                .inject();
-    }
+    /**
+     * Check to see if Boostrap is loaded already.
+     * 
+     * @return true is Boostreap loaded, false otherwise.
+     */
+    private native boolean isBootstrapLoaded() /*-{
+		return typeof $wnd['jQuery'].fn.emulateTransitionEnd !== 'undefined'
+    }-*/;
 
     /**
      * Check to see if jQuery is loaded already
@@ -49,4 +48,21 @@ public class GwtBootstrap3EntryPoint implements EntryPoint {
     private native boolean isjQueryLoaded() /*-{
         return (typeof $wnd['jQuery'] !== 'undefined');
     }-*/;
+
+    /** {@inheritDoc} */
+    @Override
+    public void onModuleLoad() {
+        if (!isjQueryLoaded()) {
+            ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.jQuery().getText())
+                    .setWindow(ScriptInjector.TOP_WINDOW)
+                    .inject();
+        }
+
+        if (!isBootstrapLoaded()) {
+            ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.bootstrap().getText())
+                .setWindow(ScriptInjector.TOP_WINDOW)
+                .inject();
+        }
+    }
+    
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3EntryPoint.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3EntryPoint.java
@@ -37,7 +37,7 @@ public class GwtBootstrap3EntryPoint implements EntryPoint {
      * @return true is Boostreap loaded, false otherwise.
      */
     private native boolean isBootstrapLoaded() /*-{
-		return typeof $wnd['jQuery'].fn.emulateTransitionEnd !== 'undefined'
+        return typeof $wnd['jQuery'].fn.emulateTransitionEnd !== 'undefined'
     }-*/;
 
     /**

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/FormLabel.java
@@ -53,15 +53,12 @@ public class FormLabel extends AbstractTextWidget {
         addHandler(new ChangeHandler() {
             @Override
             public void onChange(ChangeEvent event) {
+                if (iconElement != null) {
+                    iconElement.removeFromParent();
+                }
                 String html = getHTML();
-                if (!showRequiredIndicator || html == null || "".equals(html)) {
-                    if (iconElement != null) {
-                        iconElement.removeFromParent();
-                    }
-                } else {
-                    if (iconElement == null) {
-                        iconElement = createIconElement();
-                    }
+                if (showRequiredIndicator && html != null && !"".equals(html)) {
+                    iconElement = createIconElement();
                     getElement().appendChild(iconElement);
                 }
             }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/HelpBlock.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/HelpBlock.java
@@ -48,15 +48,12 @@ public class HelpBlock extends AbstractTextWidget {
         addHandler(new ChangeHandler() {
             @Override
             public void onChange(ChangeEvent event) {
+                if (iconElement != null) {
+                    iconElement.removeFromParent();
+                }
                 String html = getHTML();
-                if (html == null || "".equals(html)) {
-                    if (iconElement != null) {
-                        iconElement.removeFromParent();
-                    }
-                } else {
-                    if (iconElement == null) {
-                        iconElement = createIconElement();
-                    }
+                if (html != null && !"".equals(html) && iconType != null) {
+                    iconElement = createIconElement();
                     getElement().insertFirst(iconElement);
                 }
             }


### PR DESCRIPTION
 Add check for bootstrap3 prior to injecting.  We check for emulateTransitionEnd which first appears in bootstrap3 and is sufficiently unique to assume bootstrap3 is loaded.