### PR TITLE
Fixed AbstractForm firing FormPanel's SubmitEvent instead of its own one.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/form/AbstractForm.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/form/AbstractForm.java
@@ -455,12 +455,12 @@ public abstract class AbstractForm extends FormElementContainer implements
     }
 
     /**
-     * Fire a {@link FormPanel.SubmitEvent}.
+     * Fire a {@link AbstractForm.SubmitEvent}.
      *
      * @return true to continue, false if canceled
      */
     private boolean fireSubmitEvent() {
-        FormPanel.SubmitEvent event = new FormPanel.SubmitEvent();
+        SubmitEvent event = new SubmitEvent();
         fireEvent(event);
         return !event.isCanceled();
     }


### PR DESCRIPTION
AbstractForm fired FormPanel's submitevent instead of its own duplicate, which caused registered handlers not to be fired. It might be a good idea to remove the amount of copied code in AbstractForm later on.