### PR TITLE
Tooltip: allow passing null to setHtml() to set empty Tooltip (thereby

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Tooltip.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Tooltip.java
@@ -344,7 +344,10 @@ public class Tooltip implements IsWidget, HasWidgets, HasOneWidget, HasId, HasHo
      */
     public void setHtml(final SafeHtml html) {
         setIsHtml(true);
-        if (html != null) {
+        if (html == null) {
+            setTitle("");
+        }
+        else {
             setTitle(html.asString());
         }
     }


### PR DESCRIPTION
clearing any previous Tooltip value).