### PR TITLE
Several validator related fixes.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/form/AbstractForm.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/form/AbstractForm.java
@@ -20,6 +20,7 @@ import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeUri;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.FormPanel;
+import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.NamedFrame;
 import com.google.gwt.user.client.ui.RootPanel;
@@ -525,6 +526,9 @@ public abstract class AbstractForm extends FormElementContainer implements
             if (widget instanceof HasValidators<?>) {
                 result.add((HasValidators<?>) widget);
             }
+            if (widget instanceof HasOneWidget) {
+                result.addAll(getChildrenWithValidators(((HasOneWidget) widget).getWidget()));
+            }
             if (widget instanceof HasWidgets) {
                 for (Widget child : (HasWidgets) widget) {
                     result.addAll(getChildrenWithValidators(child));
@@ -533,5 +537,5 @@ public abstract class AbstractForm extends FormElementContainer implements
         }
         return result;
     }
-    
+
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/validator/BlankValidator.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/validator/BlankValidator.java
@@ -1,5 +1,7 @@
 package org.gwtbootstrap3.client.ui.form.validator;
 
+import java.util.Collection;
+
 import org.gwtbootstrap3.client.ui.form.validator.ValidationMessages.Keys;
 
 /*
@@ -55,6 +57,7 @@ public class BlankValidator<T> extends AbstractValidator<T> {
     /** {@inheritDoc} */
     @Override
     public boolean isValid(T value) {
+        if (value instanceof Collection<?>) { return ((Collection<?>) value).size() > 0; }
         return value != null && !"".equals(value.toString());
     }
 

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/validator/BlankValidator.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/validator/BlankValidator.java
@@ -51,7 +51,7 @@ public class BlankValidator<T> extends AbstractValidator<T> {
     /** {@inheritDoc} */
     @Override
     public int getPriority() {
-        return Priority.HIGHEST;
+        return Priority.LOWEST;
     }
 
     /** {@inheritDoc} */

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/validator/ValidatorWrapper.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/form/validator/ValidatorWrapper.java
@@ -54,7 +54,7 @@ public class ValidatorWrapper<T> implements Comparable<ValidatorWrapper<T>> {
     /** {@inheritDoc} */
     @Override
     public int compareTo(ValidatorWrapper<T> other) {
-        if (getName().equals(other.getName())) { return 0; }
+        if (this == other || getName().equals(other.getName())) { return 0; }
         int result = getPriority().compareTo(other.getPriority());
         if (result == 0) {
             result = getInsertionOrder().compareTo(other.getInsertionOrder());


### PR DESCRIPTION
Fixed problem with BlankValidator when the underlying type is a collection and the size of the collection is 0.  BlankValidator is now lowest priority.  Validators are validated from highest priority to lowest priority.