### PR TITLE
Reverting changes made for issue #394.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Modal.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Modal.java
@@ -104,10 +104,6 @@ public class Modal extends Div implements IsClosable {
     public Modal() {
         setStyleName(Styles.MODAL);
 
-        // We make this the default behavior in order to avoid issues like
-        // https://github.com/gwtbootstrap3/gwtbootstrap3/issues/394
-        setRemoveOnHide(true);
-
         content.add(header);
         dialog.add(content);
 


### PR DESCRIPTION
We don't want the removeOnHide to be default behavior because we don't want to remove the modal from the DOM when they are statically defined.  Users who want to remove the modal from the DOM onHide should call removeOnHide(true).