### PR TITLE
Fix AbstractButton setEnabled

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/ListBox.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/ListBox.java
@@ -38,6 +38,7 @@ public class ListBox extends com.google.gwt.user.client.ui.ListBox implements Ha
      * Creates an empty list box in single selection mode.
      */
     public ListBox() {
+        super();
         setStyleName(Styles.FORM_CONTROL);
     }
 

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/button/AbstractButton.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/button/AbstractButton.java
@@ -30,6 +30,7 @@ import org.gwtbootstrap3.client.ui.base.HasType;
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
 import org.gwtbootstrap3.client.ui.base.mixin.ActiveMixin;
 import org.gwtbootstrap3.client.ui.base.mixin.DataTargetMixin;
+import org.gwtbootstrap3.client.ui.base.mixin.EnabledMixin;
 import org.gwtbootstrap3.client.ui.base.mixin.FocusableMixin;
 import org.gwtbootstrap3.client.ui.constants.Attributes;
 import org.gwtbootstrap3.client.ui.constants.ButtonDismiss;
@@ -97,6 +98,7 @@ public abstract class AbstractButton extends ComplexWidget implements HasEnabled
     private final DataTargetMixin<AbstractButton> targetMixin = new DataTargetMixin<AbstractButton>(this);
     private final ActiveMixin<AbstractButton> activeMixin = new ActiveMixin<AbstractButton>(this);
     private final FocusableMixin<AbstractButton> focusableMixin = new FocusableMixin<AbstractButton>(this);
+    private final EnabledMixin<AbstractButton> enabledMixin = new EnabledMixin<AbstractButton>(this);
 
     /**
      * Creates button with DEFAULT type.
@@ -123,12 +125,12 @@ public abstract class AbstractButton extends ComplexWidget implements HasEnabled
 
     @Override
     public void setEnabled(final boolean enabled) {
-        getElement().setPropertyBoolean("disabled", !enabled);
+        enabledMixin.setEnabled(enabled);
     }
 
     @Override
     public boolean isEnabled() {
-        return !getElement().getPropertyBoolean("disabled");
+        return enabledMixin.isEnabled();
     }
 
     @Override


### PR DESCRIPTION
AbstractButton implementations weren't disabling.

If there's a good reason to not use the enabled mixin then the elements attribute needs to be set
```java
if(enabled) {
    getElement().setAttribute(DISABLED, "");
} else {
    getElement().removeAttribute(DISABLED);
}
```