### PR TITLE
Refactoring of Tooltip and Popover.

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedEvent.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedEvent.java
@@ -1,0 +1,64 @@
+package org.gwtbootstrap3.client.shared.event;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * @author Joshua Godi
+ */
+public class InsertedEvent extends GwtEvent<InsertedHandler> {
+    private static final Type<InsertedHandler> TYPE = new Type<InsertedHandler>();
+    private final NativeEvent nativeEvent;
+
+    public static Type<InsertedHandler> getType() {
+        return TYPE;
+    }
+
+    public InsertedEvent() {
+        this(null);
+    }
+
+    public InsertedEvent(final NativeEvent nativeEvent) {
+        this.nativeEvent = nativeEvent;
+    }
+
+    @Override
+    public final Type<InsertedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(final InsertedHandler handler) {
+        handler.onInserted(this);
+    }
+
+    public final void preventDefault() {
+        if (nativeEvent == null) return;
+        nativeEvent.preventDefault();
+    }
+
+    public final void stopPropagation() {
+        if (nativeEvent == null) return;
+        nativeEvent.stopPropagation();
+    }
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedEvent.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedEvent.java
@@ -4,7 +4,7 @@ package org.gwtbootstrap3.client.shared.event;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 GwtBootstrap3
+ * Copyright (C) 2015 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.shared.GwtEvent;
 
 /**
- * @author Joshua Godi
+ * @author Steven Jardine
  */
 public class InsertedEvent extends GwtEvent<InsertedHandler> {
     private static final Type<InsertedHandler> TYPE = new Type<InsertedHandler>();

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedHandler.java
@@ -1,0 +1,30 @@
+package org.gwtbootstrap3.client.shared.event;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * @author Steven Jardine
+ */
+public interface InsertedHandler extends EventHandler {
+    void onInserted(InsertedEvent event);
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/event/InsertedHandler.java
@@ -4,7 +4,7 @@ package org.gwtbootstrap3.client.shared.event;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 GwtBootstrap3
+ * Copyright (C) 2015 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Popover.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Popover.java
@@ -4,7 +4,7 @@ package org.gwtbootstrap3.client.ui;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 GwtBootstrap3
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,449 +20,154 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
+import org.gwtbootstrap3.client.ui.base.AbstractTooltip;
 
-import org.gwtbootstrap3.client.shared.event.HiddenEvent;
-import org.gwtbootstrap3.client.shared.event.HiddenHandler;
-import org.gwtbootstrap3.client.shared.event.HideEvent;
-import org.gwtbootstrap3.client.shared.event.HideHandler;
-import org.gwtbootstrap3.client.shared.event.ShowEvent;
-import org.gwtbootstrap3.client.shared.event.ShowHandler;
-import org.gwtbootstrap3.client.shared.event.ShownEvent;
-import org.gwtbootstrap3.client.shared.event.ShownHandler;
-import org.gwtbootstrap3.client.ui.base.HasHover;
-import org.gwtbootstrap3.client.ui.base.HasId;
-import org.gwtbootstrap3.client.ui.constants.Placement;
-import org.gwtbootstrap3.client.ui.constants.Trigger;
-
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.logical.shared.AttachEvent;
-import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.ui.HasOneWidget;
-import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.web.bindery.event.shared.HandlerRegistration;
 
 /**
- * @author Joshua Godi
+ * Basic implementation for the Bootstrap Popover
+ * <p/>
+ * <a href="http://getbootstrap.com/javascript/#popovers">Bootstrap Documentation</a>
+ * <p/>
+ * <p/>
+ * <h3>UiBinder example</h3>
+ * <p/>
+ * 
+ * <pre>
+ * {@code
+ * <b:Popover text="...">
+ *    ...
+ * </b:Popover>
+ * }
+ * </pre>
+ * <p/>
+ *
+ * @author Steven Jardine
  */
-public class Popover implements IsWidget, HasWidgets, HasOneWidget, HasId, HasHover {
-    private static final String TOGGLE = "toggle";
-    private static final String SHOW = "show";
-    private static final String HIDE = "hide";
-    private static final String DESTROY = "destroy";
+public class Popover extends AbstractTooltip {
 
-    // Defaults from http://getbootstrap.com/javascript/#popovers
-    private boolean isAnimated = true;
-    private boolean isHTML = false;
-    private Placement placement = Placement.TOP;
-    private Trigger trigger = Trigger.HOVER;
-    private String title = "";
-    private String content = "";
-    private int hideDelayMs = 0;
-    private int showDelayMs = 0;
-    private String container = null;
-    private final String selector = null;
+    private static final String TEMPLATE = "<div class=\"popover\" role=\"tooltip\"><div class=\"arrow\"></div><h3 class=\"popover-title\"></h3><div class=\"popover-content\"></div></div>";
 
-    private Widget widget;
-    private String id;
+    private String content = null;
 
+    /**
+     * Creates the empty Popover
+     */
     public Popover() {
+        super("bs.popover");
+        setAlternateTemplate(TEMPLATE);
     }
 
+    /**
+     * Creates the popover with given title. Remember to set the content and widget as well.
+     *
+     * @param title title for the popover
+     */
+    public Popover(final String title) {
+        this();
+        setTitle(title);
+    }
+
+    /**
+     * Creates the popover with given title and content. Remember to set the widget as well.
+     *
+     * @param title title for the popover
+     */
+    public Popover(final String title, String content) {
+        this();
+        setTitle(title);
+        setContent(content);
+    }
+
+    /**
+     * Creates the popover around this widget
+     *
+     * @param w widget for the popover
+     */
     public Popover(final Widget w) {
+        this();
         setWidget(w);
     }
 
-    @Override
-    public void setWidget(final Widget w) {
-        // Validate
-        if (w == widget) {
-            return;
-        }
-
-        // Detach new child
-        if (w != null) {
-            w.removeFromParent();
-        }
-
-        // Remove old child
-        if (widget != null) {
-            remove(widget);
-        }
-
-        // Logical attach, but don't physical attach; done by jquery.
-        widget = w;
-        if (widget == null) {
-            return;
-        }
-
-        // Bind jquery events
-        bindJavaScriptEvents(widget.getElement());
-
-        // When we attach it, configure the tooltip
-        widget.addAttachHandler(new AttachEvent.Handler() {
-            @Override
-            public void onAttachOrDetach(final AttachEvent event) {
-                reconfigure();
-            }
-        });
-    }
-
-    @Override
-    public void add(final Widget child) {
-        if (getWidget() != null) {
-            throw new IllegalStateException("Can only contain one child widget");
-        }
-        setWidget(child);
-    }
-
-    @Override
-    public void setWidget(final IsWidget w) {
-        widget = (w == null) ? null : w.asWidget();
-    }
-
-    @Override
-    public Widget getWidget() {
-        return widget;
-    }
-
-    @Override
-    public void setId(final String id) {
-        this.id = id;
-        if (widget != null) {
-            widget.getElement().setId(id);
-        }
-    }
-
-    @Override
-    public String getId() {
-        return (widget == null) ? id : widget.getElement().getId();
-    }
-
-    @Override
-    public void setIsAnimated(final boolean isAnimated) {
-        this.isAnimated = isAnimated;
-    }
-
-    @Override
-    public boolean isAnimated() {
-        return isAnimated;
-    }
-
-    @Override
-    public void setIsHtml(final boolean isHTML) {
-        this.isHTML = isHTML;
-    }
-
-    @Override
-    public boolean isHtml() {
-        return isHTML;
-    }
-
-    @Override
-    public void setPlacement(final Placement placement) {
-        this.placement = placement;
-    }
-
-    @Override
-    public Placement getPlacement() {
-        return placement;
-    }
-
-    @Override
-    public void setTrigger(final Trigger trigger) {
-        this.trigger = trigger;
-    }
-
-    @Override
-    public Trigger getTrigger() {
-        return trigger;
-    }
-
-    @Override
-    public void setShowDelayMs(final int showDelayMs) {
-        this.showDelayMs = showDelayMs;
-    }
-
-    @Override
-    public int getShowDelayMs() {
-        return showDelayMs;
-    }
-
-    @Override
-    public void setHideDelayMs(final int hideDelayMs) {
-        this.hideDelayMs = hideDelayMs;
-    }
-
-    @Override
-    public int getHideDelayMs() {
-        return hideDelayMs;
-    }
-
-    @Override
-    public void setContainer(final String container) {
-        this.container = container;
-    }
-
-    @Override
-    public String getContainer() {
-        return container;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setContent(final String content) {
-        this.content = content;
-    }
-
-    public void setTitle(final String title) {
-        this.title = title;
-    }
-
-    public void reconfigure() {
-        // First destroy the old tooltip
-        destroy();
-
-        // Setup the new tooltip
-        if (container != null && selector != null) {
-            popover(widget.getElement(), isAnimated, isHTML, placement.getCssName(), selector, title, content,
-                    trigger.getCssName(), showDelayMs, hideDelayMs, container);
-        } else if (container != null) {
-            popover(widget.getElement(), isAnimated, isHTML, placement.getCssName(), title, content,
-                    trigger.getCssName(), showDelayMs, hideDelayMs, container);
-        } else if (selector != null) {
-            popover(widget.getElement(), isAnimated, isHTML, placement.getCssName(), selector, title, content,
-                    trigger.getCssName(), showDelayMs, hideDelayMs);
-        } else {
-            popover(widget.getElement(), isAnimated, isHTML, placement.getCssName(), title, content,
-                    trigger.getCssName(), showDelayMs, hideDelayMs);
-        }
-    }
-
-    public void toggle() {
-        call(widget.getElement(), TOGGLE);
-    }
-
-    public void show() {
-        call(widget.getElement(), SHOW);
-    }
-
-    public void hide() {
-        call(widget.getElement(), HIDE);
-    }
-
-    public void destroy() {
-        call(widget.getElement(), DESTROY);
+    /**
+     * Creates the popover around this widget with given title and content.
+     *
+     * @param w widget for the popover
+     * @param title title for the popover
+     * @param content content for the popover
+     */
+    public Popover(final Widget w, final String title, String content) {
+        this();
+        setWidget(w);
+        setTitle(title);
+        setContent(content);
     }
 
     /**
-     * Can be override by subclasses to handle Tooltip's "show" event however
-     * it's recommended to add an event handler to the tooltip.
+     * Call the native popover method with the given argument.
      *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.ShowEvent
+     * @param e the {@link Element}.
+     * @param arg the arg
      */
-    protected void onShow(final Event evt) {
-        widget.fireEvent(new ShowEvent(evt));
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "shown" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.ShownEvent
-     */
-    protected void onShown(final Event evt) {
-        widget.fireEvent(new ShownEvent(evt));
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "hide" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.HideEvent
-     */
-    protected void onHide(final Event evt) {
-        widget.fireEvent(new HideEvent(evt));
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "hidden" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.HiddenEvent
-     */
-    protected void onHidden(final Event evt) {
-        widget.fireEvent(new HiddenEvent(evt));
-    }
-
-    public HandlerRegistration addShowHandler(final ShowHandler showHandler) {
-        return widget.addHandler(showHandler, ShowEvent.getType());
-    }
-
-    public HandlerRegistration addShownHandler(final ShownHandler shownHandler) {
-        return widget.addHandler(shownHandler, ShownEvent.getType());
-    }
-
-    public HandlerRegistration addHideHandler(final HideHandler hideHandler) {
-        return widget.addHandler(hideHandler, HideEvent.getType());
-    }
-
-    public HandlerRegistration addHiddenHandler(final HiddenHandler hiddenHandler) {
-        return widget.addHandler(hiddenHandler, HiddenEvent.getType());
-    }
-
-    @Override
-    public void clear() {
-        widget = null;
-    }
-
-    @Override
-    public Iterator<Widget> iterator() {
-        // Simple iterator for the widget
-        return new Iterator<Widget>() {
-            boolean hasElement = widget != null;
-            Widget returned = null;
-
-            @Override
-            public boolean hasNext() {
-                return hasElement;
-            }
-
-            @Override
-            public Widget next() {
-                if (!hasElement || (widget == null)) {
-                    throw new NoSuchElementException();
-                }
-                hasElement = false;
-                return (returned = widget);
-            }
-
-            @Override
-            public void remove() {
-                if (returned != null) {
-                    Popover.this.remove(returned);
-                }
-            }
-        };
-    }
-
-    @Override
-    public boolean remove(final Widget w) {
-        // Validate.
-        if (widget != w) {
-            return false;
-        }
-
-        // Logical detach.
-        clear();
-        return true;
-    }
-
-    @Override
-    public Widget asWidget() {
-        return widget;
-    }
-
-    // @formatter:off
-    private native void bindJavaScriptEvents(final Element e) /*-{
-        var target = this;
-        var $popover = $wnd.jQuery(e);
-
-        $popover.on('show.bs.popover', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Popover::onShow(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-
-        $popover.on('shown.bs.popover', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Popover::onShown(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-
-        $popover.on('hide.bs.popover', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Popover::onHide(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-
-        $popover.on('hidden.bs.popover', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Popover::onHidden(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-    }-*/;
-
     private native void call(final Element e, final String arg) /*-{
         $wnd.jQuery(e).popover(arg);
     }-*/;
 
-    private native void popover(Element e, boolean animation, boolean html, String placement, String selector,
-                                String title, String content, String trigger, int showDelay, int hideDelay, String container) /*-{
-        $wnd.jQuery(e).popover({
-            animation: animation,
-            html: html,
-            placement: placement,
-            selector: selector,
-            title: title,
-            content: content,
-            trigger: trigger,
-            delay: {
-                show: showDelay,
-                hide: hideDelay
-            },
-            container: container
-        });
+    /** {@inheritDoc} */
+    @Override
+    protected void call(String arg) {
+        call(getWidget().getElement(), arg);
+    }
+
+    /**
+     * @return the content of the popover.
+     */
+    public String getContent() {
+        return content == null ? "" : content;
+    }
+
+    @Override
+    protected void init() {
+        JavaScriptObject baseOptions = createOptions(getWidget().getElement(), isAnimated(), isHtml(), getSelector(),
+                getTrigger().getCssName(), getShowDelayMs(), getHideDelayMs(), getContainer(), prepareTemplate());
+        popover(getWidget().getElement(), baseOptions, getContent());
+        setInitialized(true);
+    }
+
+    /**
+     * Create the popover.
+     */
+    private native void popover(Element e, JavaScriptObject options, String content) /*-{
+        var target = this;
+        options['content'] = function(){
+            return target.@org.gwtbootstrap3.client.ui.Popover::getContent()();
+        };
+        $wnd.jQuery(e).popover(options);
     }-*/;
 
-    private native void popover(Element e, boolean animation, boolean html, String placement,
-                                String title, String content, String trigger, int showDelay, int hideDelay, String container) /*-{
-        $wnd.jQuery(e).popover({
-            animation: animation,
-            html: html,
-            placement: placement,
-            title: title,
-            content: content,
-            trigger: trigger,
-            delay: {
-                show: showDelay,
-                hide: hideDelay
-            },
-            container: container
-        });
+    /**
+     * @param content the content of the popover to set
+     */
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void updateTitleWhenShowing() {
+        updateTitleWhenShowing(getWidget().getElement());
+    }
+
+    /**
+     * Update the title. This should only be called when the title is already showing. It causes a small flicker but
+     * updates the title immediately.
+     *
+     * @param e the popover {@link Element}.
+     */
+    private native void updateTitleWhenShowing(Element e) /*-{
+        $wnd.jQuery(e).popover('fixTitle').popover('show');
     }-*/;
 
-    private native void popover(Element e, boolean animation, boolean html, String placement, String selector,
-                                String title, String content, String trigger, int showDelay, int hideDelay) /*-{
-        $wnd.jQuery(e).popover({
-            animation: animation,
-            html: html,
-            placement: placement,
-            selector: selector,
-            title: title,
-            content: content,
-            trigger: trigger,
-            delay: {
-                show: showDelay,
-                hide: hideDelay
-            }
-        });
-    }-*/;
-
-    private native void popover(Element e, boolean animation, boolean html, String placement,
-                                String title, String content, String trigger, int showDelay, int hideDelay) /*-{
-        $wnd.jQuery(e).popover({
-            animation: animation,
-            html: html,
-            placement: placement,
-            title: title,
-            content: content,
-            trigger: trigger,
-            delay: {
-                show: showDelay,
-                hide: hideDelay
-            }
-        });
-    }-*/;
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Tooltip.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Tooltip.java
@@ -10,7 +10,7 @@ package org.gwtbootstrap3.client.ui;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,32 +20,11 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
+import org.gwtbootstrap3.client.ui.base.AbstractTooltip;
 
-import org.gwtbootstrap3.client.shared.event.HiddenEvent;
-import org.gwtbootstrap3.client.shared.event.HiddenHandler;
-import org.gwtbootstrap3.client.shared.event.HideEvent;
-import org.gwtbootstrap3.client.shared.event.HideHandler;
-import org.gwtbootstrap3.client.shared.event.InsertedEvent;
-import org.gwtbootstrap3.client.shared.event.ShowEvent;
-import org.gwtbootstrap3.client.shared.event.ShowHandler;
-import org.gwtbootstrap3.client.shared.event.ShownEvent;
-import org.gwtbootstrap3.client.shared.event.ShownHandler;
-import org.gwtbootstrap3.client.ui.base.HasHover;
-import org.gwtbootstrap3.client.ui.base.HasId;
-import org.gwtbootstrap3.client.ui.constants.Placement;
-import org.gwtbootstrap3.client.ui.constants.Trigger;
-
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.logical.shared.AttachEvent;
-import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.ui.HasOneWidget;
-import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.web.bindery.event.shared.HandlerRegistration;
 
 /**
  * Basic implementation for the Bootstrap tooltip
@@ -65,52 +44,24 @@ import com.google.web.bindery.event.shared.HandlerRegistration;
  * </pre>
  * <p/>
  *
- * @author Joshua Godi
- * @author Pontus Enmark
  * @author Steven Jardine
  */
-public class Tooltip implements IsWidget, HasWidgets, HasOneWidget, HasId, HasHover {
-    
-    private static final String TOGGLE = "toggle";
-    private static final String SHOW = "show";
-    private static final String HIDE = "hide";
-    private static final String DESTROY = "destroy";
-
-    // Defaults from http://getbootstrap.com/javascript/#tooltips
-    private boolean isAnimated = true;
-    private boolean isHTML = false;
-    private Placement placement = Placement.TOP;
-    private Trigger trigger = Trigger.HOVER;
-    private String title = "";
-    private int hideDelayMs = 0;
-    private int showDelayMs = 0;
-    private String container = null;
-    private String selector = null;
-
-    private String tooltipClassNames = "tooltip";
-    private String tooltipArrowClassNames = "tooltip-arrow";
-    private String tooltipInnerClassNames = "tooltip-inner";
-
-    private final static String DEFAULT_TEMPLATE = "<div class=\"{0}\"><div class=\"{1}\"></div><div class=\"{2}\"></div></div>";
-    private String alternateTemplate = null;
-
-    private Widget widget;
-    private String id;
-    private boolean initialized = false;
-    private boolean showing = false;
+public class Tooltip extends AbstractTooltip {
 
     /**
-     * Creates the empty Tooltip
+     * Creates the empty Popover
      */
     public Tooltip() {
+        super("bs.tooltip");
     }
 
     /**
-     * Creates the tooltip with given title. Remember to set the widget as well
+     * Creates the tooltip with given title. Remember to set the content and widget as well.
      *
      * @param title title for the tooltip
      */
     public Tooltip(final String title) {
+        this();
         setTitle(title);
     }
 
@@ -120,678 +71,65 @@ public class Tooltip implements IsWidget, HasWidgets, HasOneWidget, HasId, HasHo
      * @param w widget for the tooltip
      */
     public Tooltip(final Widget w) {
+        this();
         setWidget(w);
     }
 
     /**
-     * Creates the tooltip around this widget with given title
+     * Creates the tooltip around this widget with given title and content.
      *
      * @param w widget for the tooltip
      * @param title title for the tooltip
      */
     public Tooltip(final Widget w, final String title) {
+        this();
         setWidget(w);
         setTitle(title);
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void add(final Widget child) {
-        if (getWidget() != null) {
-            throw new IllegalStateException("Can only contain one child widget");
-        }
-        setWidget(child);
-    }
-
-    /**
-     * Adds a hidden handler to the Tooltip that will be fired when the Tooltip's hidden event is fired
+     * Call the native tooltip method with the given argument.
      *
-     * @param hiddenHandler HiddenHandler to handle the hidden event
-     * @return HandlerRegistration of the handler
+     * @param e the {@link Element}.
+     * @param arg the arg
      */
-    public HandlerRegistration addHiddenHandler(final HiddenHandler hiddenHandler) {
-        return widget.addHandler(hiddenHandler, HiddenEvent.getType());
-    }
-
-    /**
-     * Adds a hide handler to the Tooltip that will be fired when the Tooltip's hide event is fired
-     *
-     * @param hideHandler HideHandler to handle the hide event
-     * @return HandlerRegistration of the handler
-     */
-    public HandlerRegistration addHideHandler(final HideHandler hideHandler) {
-        return widget.addHandler(hideHandler, HideEvent.getType());
-    }
-
-    /**
-     * Adds a show handler to the Tooltip that will be fired when the Tooltip's show event is fired
-     *
-     * @param showHandler ShowHandler to handle the show event
-     * @return HandlerRegistration of the handler
-     */
-    public HandlerRegistration addShowHandler(final ShowHandler showHandler) {
-        return widget.addHandler(showHandler, ShowEvent.getType());
-    }
-
-    /**
-     * Adds a shown handler to the Tooltip that will be fired when the Tooltip's shown event is fired
-     *
-     * @param shownHandler ShownHandler to handle the shown event
-     * @return HandlerRegistration of the handler
-     */
-    public HandlerRegistration addShownHandler(final ShownHandler shownHandler) {
-        return widget.addHandler(shownHandler, ShownEvent.getType());
-    }
-
-    /**
-     * Add a tooltip arrow div class name
-     *
-     * @param tooltipArrowClassName a tooltip arrow div class name
-     */
-    public void addTooltipArrowClassName(String tooltipArrowClassName) {
-        this.tooltipArrowClassNames += " " + tooltipArrowClassName;
-    }
-
-    /**
-     * Add a tooltip div class name
-     *
-     * @param tooltipClassName a tooltip div class name
-     */
-    public void addTooltipClassName(String tooltipClassName) {
-        this.tooltipClassNames += " " + tooltipClassName;
-    }
-
-    /**
-     * Add a tooltip inner div class name
-     *
-     * @param tooltipInnerClassName a tooltip inner div class name
-     */
-    public void addTooltipInnerClassName(String tooltipInnerClassName) {
-        this.tooltipInnerClassNames += " " + tooltipInnerClassName;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Widget asWidget() {
-        return widget;
-    }
-
-    // @formatter:off
-    private native void bindJavaScriptEvents(final Element e) /*-{
-        var target = this;
-        var $tooltip = $wnd.jQuery(e);
-        $tooltip.on('show.bs.tooltip', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Tooltip::onShow(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-        $tooltip.on('shown.bs.tooltip', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Tooltip::onShown(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-        $tooltip.on('hide.bs.tooltip', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Tooltip::onHide(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-        $tooltip.on('hidden.bs.tooltip', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Tooltip::onHidden(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-        $tooltip.on('inserted.bs.tooltip', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Tooltip::onInserted(Lcom/google/gwt/user/client/Event;)(evt);
-        });
-    }-*/;
-
     private native void call(final Element e, final String arg) /*-{
         $wnd.jQuery(e).tooltip(arg);
     }-*/;
 
     /** {@inheritDoc} */
     @Override
-    public void clear() {
-        widget = null;
+    protected void call(String arg) {
+        call(getWidget().getElement(), arg);
     }
 
-    /**
-     * Force the Tooltip to be destroyed
-     */
-    public void destroy() {
-        call(widget.getElement(), DESTROY);
-    }
-
-    /**
-     * Get the alternate template used to render the tooltip. If null,
-     * the default template will be used.
-     *
-     * @return String the alternate template used to render the tooltip
-     */
-    public String getAlternateTemplate() {
-        return alternateTemplate;
-    }
-
-    /** {@inheritDoc} */
     @Override
-    public String getContainer() {
-        return container;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public int getHideDelayMs() {
-        return hideDelayMs;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getId() {
-        return (widget == null) ? id : widget.getElement().getId();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Placement getPlacement() {
-        return placement;
-    }
-
-    /**
-     * Gets the placement css name.
-     *
-     * @return the placement css name
-     */
-    private String getPlacementCssName() {
-        return placement == null ? Placement.TOP.getCssName() : placement.getCssName();
-    }
-
-    /**
-     * Get the tooltip's selector
-     *
-     * @return String the tooltip's selector
-     */
-    public String getSelector() {
-        return selector;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public int getShowDelayMs() {
-        return showDelayMs;
-    }
-
-    /**
-     * Gets the tooltip's display string
-     *
-     * @return String tooltip display string
-     */
-    public String getTitle() {
-        return title;
-    }
-
-    /**
-     * Get the tooltip arrow div class names
-     *
-     * @return String Get the tooltip arrow div class names
-     */
-    public String getTooltipArrowClassNames() {
-        return tooltipArrowClassNames;
-    }
-
-    /**
-     * Get the tooltip div class names
-     *
-     * @return String the tooltip div class names
-     */
-    public String getTooltipClassNames() {
-        return tooltipClassNames;
-    }
-
-    /**
-     * Get the tooltip inner div class names
-     *
-     * @return String the tooltip inner div class names
-     */
-    public String getTooltipInnerClassNames() {
-        return tooltipInnerClassNames;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Trigger getTrigger() {
-        return trigger;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Widget getWidget() {
-        return widget;
-    }
-
-    /**
-     * Force hide the Tooltip
-     */
-    public void hide() {
-        call(widget.getElement(), HIDE);
-    }
-
-    /**
-     * Initializes the tooltip for use.
-     */
-    private void init() {
-        tooltip(widget.getElement(), isAnimated, isHTML, selector, trigger.getCssName(), showDelayMs, hideDelayMs,
-                container, prepareTemplate());
-        initialized = true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isAnimated() {
-        return isAnimated;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isHtml() {
-        return isHTML;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Iterator<Widget> iterator() {
-        // Simple iterator for the widget
-        return new Iterator<Widget>() {
-
-            boolean hasElement = widget != null;
-
-            Widget returned = null;
-
-            /** {@inheritDoc} */
-            @Override
-            public boolean hasNext() {
-                return hasElement;
-            }
-
-            /** {@inheritDoc} */
-            @Override
-            public Widget next() {
-                if (!hasElement || (widget == null)) {
-                    throw new NoSuchElementException();
-                }
-                hasElement = false;
-                return (returned = widget);
-            }
-
-            /** {@inheritDoc} */
-            @Override
-            public void remove() {
-                if (returned != null) {
-                    Tooltip.this.remove(returned);
-                }
-            }
-        };
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "hidden" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.HiddenEvent
-     */
-    protected void onHidden(final Event evt) {
-        showing = false;
-        widget.fireEvent(new HiddenEvent(evt));
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "hide" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.HideEvent
-     */
-    protected void onHide(final Event evt) {
-        widget.fireEvent(new HideEvent(evt));
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "inserted" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.InsertedEvent
-     */
-    protected void onInserted(final Event evt) {
-        widget.fireEvent(new InsertedEvent(evt));
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "show" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see org.gwtbootstrap3.client.shared.event.ShowEvent
-     */
-    protected void onShow(final Event evt) {
-        widget.fireEvent(new ShowEvent(evt));
-    }
-
-    /**
-     * Can be override by subclasses to handle Tooltip's "shown" event however
-     * it's recommended to add an event handler to the tooltip.
-     *
-     * @param evt Event
-     * @see ShownEvent
-     */
-    protected void onShown(final Event evt) {
-        showing = true;
-        widget.fireEvent(new ShownEvent(evt));
-    }
-
-    protected String prepareTemplate() {
-        String template = null;
-        if (alternateTemplate == null) {
-            template = DEFAULT_TEMPLATE.replace("{0}", getTooltipClassNames());
-            template = template.replace("{1}", getTooltipArrowClassNames());
-            template = template.replace("{2}", getTooltipInnerClassNames());
-        } else {
-            template = alternateTemplate;
-        }
-        return template;
-    }
-
-    /**
-     * Reconfigures the tooltip.
-     * 
-     * @deprecated will be removed after the next release.
-     */
-    public void reconfigure() {
-        //Do nothing.  No longer necessary.
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public boolean remove(final Widget w) {
-        // Validate.
-        if (widget != w) {
-            return false;
-        }
-        // Logical detach.
-        clear();
-        return true;
-    }
-
-    /**
-     * Set the alternate template used to render the tooltip. The template should contain
-     * divs with classes 'tooltip', 'tooltip-inner', and 'tooltip-arrow'. If an alternate
-     * template is configured, the 'tooltipClassNames', 'tooltipArrowClassNames', and
-     * 'tooltipInnerClassNames' properties are not used.
-     *
-     * @param alternateTemplate the alternate template used to render the tooltip
-     */
-    public void setAlternateTemplate(String alternateTemplate) {
-        this.alternateTemplate = alternateTemplate;
-        if (initialized) {
-            updateString(widget.getElement(), "template", prepareTemplate());
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setContainer(final String container) {
-        this.container = container;
-        if (initialized) {
-            updateString(widget.getElement(), "container", container);
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setHideDelayMs(final int hideDelayMs) {
-        this.hideDelayMs = hideDelayMs;
-        if (initialized) {
-            updateDelay(widget.getElement(), showDelayMs, hideDelayMs);
-        }
-    }
-
-    /**
-     * Sets the tooltip's display string in HTML format
-     *
-     * @param text String display string in HTML format
-     */
-    public void setHtml(final SafeHtml html) {
-        setIsHtml(true);
-        if (html == null) {
-            setTitle("");
-        } else {
-            setTitle(html.asString());
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setId(final String id) {
-        this.id = id;
-        if (widget != null) {
-            widget.getElement().setId(id);
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setIsAnimated(final boolean isAnimated) {
-        this.isAnimated = isAnimated;
-        if (initialized) {
-            updateBool(widget.getElement(), "animation", isAnimated);
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setIsHtml(final boolean isHTML) {
-        this.isHTML = isHTML;
-        if (initialized) {
-            updateBool(widget.getElement(), "html", isHTML);
-        }
-
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setPlacement(final Placement placement) {
-        this.placement = placement;
-        if (initialized) {
-            updateString(widget.getElement(), "placement", getPlacementCssName());
-        }
-    }
-
-    /**
-     * Set the tooltip's selector
-     *
-     * @param selector the tooltip's selector
-     */
-    public void setSelector(String selector) {
-        this.selector = selector;
-        if (initialized) {
-            updateString(widget.getElement(), "selector", selector);
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setShowDelayMs(final int showDelayMs) {
-        this.showDelayMs = showDelayMs;
-        if (initialized) {
-            updateDelay(widget.getElement(), showDelayMs, hideDelayMs);
-        }
-    }
-
-    /**
-     * Convenience method. Sets the tooltop's display string.
-     * 
-     * @param text String display string.
-     * @deprecated use {@link #setTitle(String)}.
-     */
-    public void setText(String text) {
-        setTitle(text);
-    }
-
-    /**
-     * Sets the tooltip's display string
-     *
-     * @param title String display string
-     */
-    public void setTitle(final String title) {
-        this.title = title;
-        if (initialized) {
-            updateString(widget.getElement(), "title", this.title);
-            if (showing) {
-                updateTitleWhenShowing(widget.getElement());
-            }
-        }
-    }
-
-    /**
-     * Set the tooltip arrow div class names
-     *
-     * @param tooltipArrowClassNames the tooltip arrow div class names
-     */
-    public void setTooltipArrowClassNames(String tooltipArrowClassNames) {
-        this.tooltipArrowClassNames = tooltipArrowClassNames;
-    }
-
-    /**
-     * Set the tooltip div class names
-     *
-     * @param tooltipClassNames the tooltip div class names
-     */
-    public void setTooltipClassNames(String tooltipClassNames) {
-        this.tooltipClassNames = tooltipClassNames;
-    }
-
-    /**
-     * Set the tooltip inner div class names
-     *
-     * @param tooltipInnerClassNames the tooltip inner div class names
-     */
-    public void setTooltipInnerClassNames(String tooltipInnerClassNames) {
-        this.tooltipInnerClassNames = tooltipInnerClassNames;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setTrigger(final Trigger trigger) {
-        this.trigger = trigger;
-        if (initialized) {
-            updateString(widget.getElement(), "trigger",
-                    trigger == null ? Trigger.HOVER.getCssName() : trigger.getCssName());
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setWidget(final IsWidget w) {
-        setWidget(w.asWidget());
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setWidget(final Widget w) {
-        // Validate
-        if (w == widget) {
-            return;
-        }
-
-        // Detach new child
-        if (w != null) {
-            w.removeFromParent();
-        }
-
-        // Remove old child
-        if (widget != null) {
-            remove(widget);
-        }
-
-        // Logical attach, but don't physical attach; done by jquery.
-        widget = w;
-        if (widget == null) {
-            return;
-        }
-
-        // Bind jquery events
-        bindJavaScriptEvents(widget.getElement());
-
-        // When we attach it, configure the tooltip
-        widget.addAttachHandler(new AttachEvent.Handler() {
-
-            @Override
-            public void onAttachOrDetach(final AttachEvent event) {
-                init();
-            }
-        });
-    }
-
-    /**
-     * Force show the Tooltip
-     */
-    public void show() {
-        call(widget.getElement(), SHOW);
-    }
-
-    /**
-     * Toggle the Tooltip to either show/hide
-     */
-    public void toggle() {
-        call(widget.getElement(), TOGGLE);
+    protected void init() {
+        JavaScriptObject baseOptions = createOptions(getWidget().getElement(), isAnimated(), isHtml(), getSelector(),
+                getTrigger().getCssName(), getShowDelayMs(), getHideDelayMs(), getContainer(), prepareTemplate());
+        tooltip(getWidget().getElement(), baseOptions);
+        setInitialized(true);
     }
 
     /**
      * Create the tooltip.
      */
-    private native void tooltip(Element e, boolean animation, boolean html, String selector, String trigger,
-            int showDelay, int hideDelay, String container, String template) /*-{
-        var target = this;
-        var options = {
-            animation : animation,
-            delay : {
-                show : showDelay,
-                hide : hideDelay
-            },
-            html : html,
-            placement : function(tip, element) {
-                return target.@org.gwtbootstrap3.client.ui.Tooltip::getPlacementCssName()();
-            },
-            template : template,
-            title : function() {
-                return target.@org.gwtbootstrap3.client.ui.Tooltip::getTitle()();
-            },
-            trigger : trigger
-        };
-        if (selector) {
-            options['selector'] = selector;
-        }
-        if (container) {
-            options['container'] = container;
-        }
+    private native void tooltip(Element e, JavaScriptObject options) /*-{
         $wnd.jQuery(e).tooltip(options);
     }-*/;
 
     /** {@inheritDoc} */
     @Override
-    public String toString() {
-        return asWidget().toString();
+    protected void updateTitleWhenShowing() {
+        updateTitleWhenShowing(getWidget().getElement());
     }
 
-    private native void updateBool(Element e, String option, boolean value) /*-{
-        $wnd.jQuery(e).data('bs.tooltip').options[option] = value;
-    }-*/;
-
-    private native void updateDelay(Element e, int showDelay, int hideDealy) /*-{
-        $wnd.jQuery(e).data('bs.tooltip').options['delay'] = {
-            show : showDelay,
-            hide : hideDelay
-        };
-    }-*/;
-
-    private native void updateString(Element e, String option, String value) /*-{
-        $wnd.jQuery(e).data('bs.tooltip').options[option] = value;
-    }-*/;
-
+    /**
+     * Update the title. This should only be called when the title is already showing. It causes a small flicker but
+     * updates the title immediately.
+     *
+     * @param e the tooltip {@link Element}.
+     */
     private native void updateTitleWhenShowing(Element e) /*-{
         $wnd.jQuery(e).tooltip('fixTitle').tooltip('show');
     }-*/;

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/TooltipHelpBlock.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/TooltipHelpBlock.java
@@ -25,8 +25,6 @@ import org.gwtbootstrap3.client.ui.constants.Placement;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.DomEvent;
 
 /**
@@ -74,12 +72,6 @@ public class TooltipHelpBlock extends Tooltip {
                 }
             }
         };
-        helpBlock.addDomHandler(new ChangeHandler() {
-            @Override
-            public void onChange(final ChangeEvent event) {
-                reconfigure();
-            }
-        }, ChangeEvent.getType());
         helpBlock.getElement().getStyle().setPaddingLeft(0, Unit.PX);
         helpBlock.setIconType(IconType.EXCLAMATION_TRIANGLE);
         setWidget(helpBlock);

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/AbstractTooltip.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/AbstractTooltip.java
@@ -1,0 +1,802 @@
+package org.gwtbootstrap3.client.ui.base;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.gwtbootstrap3.client.shared.event.HiddenEvent;
+import org.gwtbootstrap3.client.shared.event.HiddenHandler;
+import org.gwtbootstrap3.client.shared.event.HideEvent;
+import org.gwtbootstrap3.client.shared.event.HideHandler;
+import org.gwtbootstrap3.client.shared.event.InsertedEvent;
+import org.gwtbootstrap3.client.shared.event.ShowEvent;
+import org.gwtbootstrap3.client.shared.event.ShowHandler;
+import org.gwtbootstrap3.client.shared.event.ShownEvent;
+import org.gwtbootstrap3.client.shared.event.ShownHandler;
+import org.gwtbootstrap3.client.ui.constants.Placement;
+import org.gwtbootstrap3.client.ui.constants.Trigger;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.web.bindery.event.shared.HandlerRegistration;
+
+/**
+ * Common implementation for the Bootstrap tooltip and popover.
+ *
+ * @author Joshua Godi
+ * @author Pontus Enmark
+ * @author Steven Jardine
+ */
+public abstract class AbstractTooltip implements IsWidget, HasWidgets, HasOneWidget, HasId, HasHover {
+    
+    private final static String DEFAULT_TEMPLATE = "<div class=\"{0}\"><div class=\"{1}\"></div><div class=\"{2}\"></div></div>";
+    private static final String DESTROY = "destroy";
+    private static final String HIDE = "hide";
+    private static final String SHOW = "show";
+
+    private static final String TOGGLE = "toggle";
+    private String alternateTemplate = null;
+    private String container = null;
+    private final String dataTarget;
+    private int hideDelayMs = 0;
+    private String id;
+    private boolean initialized = false;
+    // Defaults from http://getbootstrap.com/javascript/#tooltips
+    private boolean isAnimated = true;
+    private boolean isHTML = false;
+
+    private Placement placement = Placement.TOP;
+    private String selector = null;
+    private int showDelayMs = 0;
+
+    private boolean showing = false;
+    private String title = "";
+
+    private String tooltipArrowClassNames = "tooltip-arrow";
+    private String tooltipClassNames = "tooltip";
+    private String tooltipInnerClassNames = "tooltip-inner";
+    private Trigger trigger = Trigger.HOVER;
+    private Widget widget;
+
+    /**
+     * Creates the empty Tooltip
+     */
+    public AbstractTooltip(String dataTarget) {
+        this.dataTarget = dataTarget;
+    }
+
+    /**
+     * Creates the tooltip with given title. Remember to set the widget as well
+     *
+     * @param title title for the tooltip
+     */
+    public AbstractTooltip(String dataTarget, final String title) {
+        this(dataTarget);
+        setTitle(title);
+    }
+
+    /**
+     * Creates the tooltip around this widget
+     *
+     * @param w widget for the tooltip
+     */
+    public AbstractTooltip(String dataTarget, final Widget w) {
+        this(dataTarget);
+        setWidget(w);
+    }
+
+    /**
+     * Creates the tooltip around this widget with given title
+     *
+     * @param w widget for the tooltip
+     * @param title title for the tooltip
+     */
+    public AbstractTooltip(String dataTarget, final Widget w, final String title) {
+        this(dataTarget);
+        setWidget(w);
+        setTitle(title);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void add(final Widget child) {
+        if (getWidget() != null) {
+            throw new IllegalStateException("Can only contain one child widget");
+        }
+        setWidget(child);
+    }
+
+    /**
+     * Adds a hidden handler to the Tooltip that will be fired when the Tooltip's hidden event is fired
+     *
+     * @param hiddenHandler HiddenHandler to handle the hidden event
+     * @return HandlerRegistration of the handler
+     */
+    public HandlerRegistration addHiddenHandler(final HiddenHandler hiddenHandler) {
+        return widget.addHandler(hiddenHandler, HiddenEvent.getType());
+    }
+
+    /**
+     * Adds a hide handler to the Tooltip that will be fired when the Tooltip's hide event is fired
+     *
+     * @param hideHandler HideHandler to handle the hide event
+     * @return HandlerRegistration of the handler
+     */
+    public HandlerRegistration addHideHandler(final HideHandler hideHandler) {
+        return widget.addHandler(hideHandler, HideEvent.getType());
+    }
+
+    /**
+     * Adds a show handler to the Tooltip that will be fired when the Tooltip's show event is fired
+     *
+     * @param showHandler ShowHandler to handle the show event
+     * @return HandlerRegistration of the handler
+     */
+    public HandlerRegistration addShowHandler(final ShowHandler showHandler) {
+        return widget.addHandler(showHandler, ShowEvent.getType());
+    }
+
+    /**
+     * Adds a shown handler to the Tooltip that will be fired when the Tooltip's shown event is fired
+     *
+     * @param shownHandler ShownHandler to handle the shown event
+     * @return HandlerRegistration of the handler
+     */
+    public HandlerRegistration addShownHandler(final ShownHandler shownHandler) {
+        return widget.addHandler(shownHandler, ShownEvent.getType());
+    }
+
+    /**
+     * Add a tooltip arrow div class name
+     *
+     * @param tooltipArrowClassName a tooltip arrow div class name
+     */
+    public void addTooltipArrowClassName(String tooltipArrowClassName) {
+        this.tooltipArrowClassNames += " " + tooltipArrowClassName;
+    }
+
+    /**
+     * Add a tooltip div class name
+     *
+     * @param tooltipClassName a tooltip div class name
+     */
+    public void addTooltipClassName(String tooltipClassName) {
+        this.tooltipClassNames += " " + tooltipClassName;
+    }
+
+    /**
+     * Add a tooltip inner div class name
+     *
+     * @param tooltipInnerClassName a tooltip inner div class name
+     */
+    public void addTooltipInnerClassName(String tooltipInnerClassName) {
+        this.tooltipInnerClassNames += " " + tooltipInnerClassName;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Widget asWidget() {
+        return widget;
+    }
+
+    // @formatter:off
+    private native void bindJavaScriptEvents(final Element e) /*-{
+        var target = this;
+        var $tooltip = $wnd.jQuery(e);
+        var dataTarget = target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::dataTarget;
+        $tooltip.on('show.' + dataTarget, function (evt) {
+            target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::onShow(Lcom/google/gwt/user/client/Event;)(evt);
+        });
+        $tooltip.on('shown.' + dataTarget, function (evt) {
+            target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::onShown(Lcom/google/gwt/user/client/Event;)(evt);
+        });
+        $tooltip.on('hide.' + dataTarget, function (evt) {
+            target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::onHide(Lcom/google/gwt/user/client/Event;)(evt);
+        });
+        $tooltip.on('hidden.' + dataTarget, function (evt) {
+            target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::onHidden(Lcom/google/gwt/user/client/Event;)(evt);
+        });
+        $tooltip.on('inserted.' + dataTarget, function (evt) {
+            target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::onInserted(Lcom/google/gwt/user/client/Event;)(evt);
+        });
+    }-*/;
+
+    protected abstract void call(final String arg);
+
+    /** {@inheritDoc} */
+    @Override
+    public void clear() {
+        widget = null;
+    }
+
+    /**
+     * Create the options for the tooltip.
+     */
+    protected native JavaScriptObject createOptions(Element e, boolean animation, boolean html, String selector,
+            String trigger, int showDelay, int hideDelay, String container, String template) /*-{
+        var target = this;
+        var options = {
+            animation : animation,
+            delay : {
+                show : showDelay,
+                hide : hideDelay
+            },
+            html : html,
+            placement : function(tip, element) {
+                return target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::getPlacementCssName()();
+            },
+            template : template,
+            title : function() {
+                return target.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::getTitle()();
+            },
+            trigger : trigger
+        };
+        if (selector) {
+            options['selector'] = selector;
+        }
+        if (container) {
+            options['container'] = container;
+        }
+        return options;
+    }-*/;
+
+    /**
+     * Force the Tooltip to be destroyed
+     */
+    public void destroy() {
+        call(DESTROY);
+    }
+
+    /**
+     * Get the alternate template used to render the tooltip. If null,
+     * the default template will be used.
+     *
+     * @return String the alternate template used to render the tooltip
+     */
+    public String getAlternateTemplate() {
+        return alternateTemplate;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getContainer() {
+        return container;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getHideDelayMs() {
+        return hideDelayMs;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getId() {
+        return (widget == null) ? id : widget.getElement().getId();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Placement getPlacement() {
+        return placement;
+    }
+
+    /**
+     * Gets the placement css name.
+     *
+     * @return the placement css name
+     */
+    private String getPlacementCssName() {
+        return placement == null ? Placement.TOP.getCssName() : placement.getCssName();
+    }
+
+    /**
+     * Get the tooltip's selector
+     *
+     * @return String the tooltip's selector
+     */
+    public String getSelector() {
+        return selector;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getShowDelayMs() {
+        return showDelayMs;
+    }
+
+    /**
+     * Gets the tooltip's display string
+     *
+     * @return String tooltip display string
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Get the tooltip arrow div class names
+     *
+     * @return String Get the tooltip arrow div class names
+     */
+    public String getTooltipArrowClassNames() {
+        return tooltipArrowClassNames;
+    }
+
+    /**
+     * Get the tooltip div class names
+     *
+     * @return String the tooltip div class names
+     */
+    public String getTooltipClassNames() {
+        return tooltipClassNames;
+    }
+
+    /**
+     * Get the tooltip inner div class names
+     *
+     * @return String the tooltip inner div class names
+     */
+    public String getTooltipInnerClassNames() {
+        return tooltipInnerClassNames;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Trigger getTrigger() {
+        return trigger;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Widget getWidget() {
+        return widget;
+    }
+
+    /**
+     * Force hide the Tooltip
+     */
+    public void hide() {
+        call(HIDE);
+    }
+
+    /**
+     * Initializes the tooltip for use.
+     */
+    protected abstract void init();
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isAnimated() {
+        return isAnimated;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isHtml() {
+        return isHTML;
+    }
+
+    /**
+     * @return the initialized
+     */
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterator<Widget> iterator() {
+        // Simple iterator for the widget
+        return new Iterator<Widget>() {
+
+            boolean hasElement = widget != null;
+
+            Widget returned = null;
+
+            /** {@inheritDoc} */
+            @Override
+            public boolean hasNext() {
+                return hasElement;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Widget next() {
+                if (!hasElement || (widget == null)) {
+                    throw new NoSuchElementException();
+                }
+                hasElement = false;
+                return (returned = widget);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void remove() {
+                if (returned != null) {
+                    AbstractTooltip.this.remove(returned);
+                }
+            }
+        };
+    }
+
+    /**
+     * Can be override by subclasses to handle Tooltip's "hidden" event however
+     * it's recommended to add an event handler to the tooltip.
+     *
+     * @param evt Event
+     * @see org.gwtbootstrap3.client.shared.event.HiddenEvent
+     */
+    protected void onHidden(final Event evt) {
+        showing = false;
+        widget.fireEvent(new HiddenEvent(evt));
+    }
+
+    /**
+     * Can be override by subclasses to handle Tooltip's "hide" event however
+     * it's recommended to add an event handler to the tooltip.
+     *
+     * @param evt Event
+     * @see org.gwtbootstrap3.client.shared.event.HideEvent
+     */
+    protected void onHide(final Event evt) {
+        widget.fireEvent(new HideEvent(evt));
+    }
+
+    /**
+     * Can be override by subclasses to handle Tooltip's "inserted" event however
+     * it's recommended to add an event handler to the tooltip.
+     *
+     * @param evt Event
+     * @see org.gwtbootstrap3.client.shared.event.InsertedEvent
+     */
+    protected void onInserted(final Event evt) {
+        widget.fireEvent(new InsertedEvent(evt));
+    }
+
+    /**
+     * Can be override by subclasses to handle Tooltip's "show" event however
+     * it's recommended to add an event handler to the tooltip.
+     *
+     * @param evt Event
+     * @see org.gwtbootstrap3.client.shared.event.ShowEvent
+     */
+    protected void onShow(final Event evt) {
+        widget.fireEvent(new ShowEvent(evt));
+    }
+
+    /**
+     * Can be override by subclasses to handle Tooltip's "shown" event however
+     * it's recommended to add an event handler to the tooltip.
+     *
+     * @param evt Event
+     * @see ShownEvent
+     */
+    protected void onShown(final Event evt) {
+        showing = true;
+        widget.fireEvent(new ShownEvent(evt));
+    }
+
+    protected String prepareTemplate() {
+        String template = null;
+        if (alternateTemplate == null) {
+            template = DEFAULT_TEMPLATE.replace("{0}", getTooltipClassNames());
+            template = template.replace("{1}", getTooltipArrowClassNames());
+            template = template.replace("{2}", getTooltipInnerClassNames());
+        } else {
+            template = alternateTemplate;
+        }
+        return template;
+    }
+
+    /**
+     * Reconfigures the tooltip.
+     * 
+     * @deprecated will be removed after the next release.
+     */
+    public void reconfigure() {
+        // Do nothing. No longer necessary.
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean remove(final Widget w) {
+        // Validate.
+        if (widget != w) {
+            return false;
+        }
+        // Logical detach.
+        clear();
+        return true;
+    }
+
+    /**
+     * Set the alternate template used to render the tooltip. The template should contain
+     * divs with classes 'tooltip', 'tooltip-inner', and 'tooltip-arrow'. If an alternate
+     * template is configured, the 'tooltipClassNames', 'tooltipArrowClassNames', and
+     * 'tooltipInnerClassNames' properties are not used.
+     *
+     * @param alternateTemplate the alternate template used to render the tooltip
+     */
+    public void setAlternateTemplate(String alternateTemplate) {
+        this.alternateTemplate = alternateTemplate;
+        if (initialized) {
+            updateString(widget.getElement(), "template", prepareTemplate());
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setContainer(final String container) {
+        this.container = container;
+        if (initialized) {
+            updateString(widget.getElement(), "container", container);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setHideDelayMs(final int hideDelayMs) {
+        this.hideDelayMs = hideDelayMs;
+        if (initialized) {
+            updateDelay(widget.getElement(), showDelayMs, hideDelayMs);
+        }
+    }
+
+    /**
+     * Sets the tooltip's display string in HTML format
+     *
+     * @param text String display string in HTML format
+     */
+    public void setHtml(final SafeHtml html) {
+        setIsHtml(true);
+        if (html == null) {
+            setTitle("");
+        } else {
+            setTitle(html.asString());
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setId(final String id) {
+        this.id = id;
+        if (widget != null) {
+            widget.getElement().setId(id);
+        }
+    }
+
+    /**
+     * @param initialized the initialized to set
+     */
+    public void setInitialized(boolean initialized) {
+        this.initialized = initialized;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setIsAnimated(final boolean isAnimated) {
+        this.isAnimated = isAnimated;
+        if (initialized) {
+            updateBool(widget.getElement(), "animation", isAnimated);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setIsHtml(final boolean isHTML) {
+        this.isHTML = isHTML;
+        if (initialized) {
+            updateBool(widget.getElement(), "html", isHTML);
+        }
+
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setPlacement(final Placement placement) {
+        this.placement = placement;
+        if (initialized) {
+            updateString(widget.getElement(), "placement", getPlacementCssName());
+        }
+    }
+
+    /**
+     * Set the tooltip's selector
+     *
+     * @param selector the tooltip's selector
+     */
+    public void setSelector(String selector) {
+        this.selector = selector;
+        if (initialized) {
+            updateString(widget.getElement(), "selector", selector);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setShowDelayMs(final int showDelayMs) {
+        this.showDelayMs = showDelayMs;
+        if (initialized) {
+            updateDelay(widget.getElement(), showDelayMs, hideDelayMs);
+        }
+    }
+
+    /**
+     * Convenience method. Sets the tooltop's display string.
+     * 
+     * @param text String display string.
+     * @deprecated use {@link #setTitle(String)}.
+     */
+    public void setText(String text) {
+        setTitle(text);
+    }
+
+    /**
+     * Sets the tooltip's display string
+     *
+     * @param title String display string
+     */
+    public void setTitle(final String title) {
+        this.title = title;
+        if (initialized) {
+            updateString(widget.getElement(), "title", this.title);
+            if (showing) {
+                updateTitleWhenShowing();
+            }
+        }
+    }
+
+    /**
+     * Set the tooltip arrow div class names
+     *
+     * @param tooltipArrowClassNames the tooltip arrow div class names
+     */
+    public void setTooltipArrowClassNames(String tooltipArrowClassNames) {
+        this.tooltipArrowClassNames = tooltipArrowClassNames;
+    }
+
+    /**
+     * Set the tooltip div class names
+     *
+     * @param tooltipClassNames the tooltip div class names
+     */
+    public void setTooltipClassNames(String tooltipClassNames) {
+        this.tooltipClassNames = tooltipClassNames;
+    }
+
+    /**
+     * Set the tooltip inner div class names
+     *
+     * @param tooltipInnerClassNames the tooltip inner div class names
+     */
+    public void setTooltipInnerClassNames(String tooltipInnerClassNames) {
+        this.tooltipInnerClassNames = tooltipInnerClassNames;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setTrigger(final Trigger trigger) {
+        this.trigger = trigger;
+        if (initialized) {
+            updateString(widget.getElement(), "trigger",
+                    trigger == null ? Trigger.HOVER.getCssName() : trigger.getCssName());
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setWidget(final IsWidget w) {
+        setWidget(w.asWidget());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setWidget(final Widget w) {
+        // Validate
+        if (w == widget) {
+            return;
+        }
+
+        // Detach new child
+        if (w != null) {
+            w.removeFromParent();
+        }
+
+        // Remove old child
+        if (widget != null) {
+            remove(widget);
+        }
+
+        // Logical attach, but don't physical attach; done by jquery.
+        widget = w;
+        if (widget == null) {
+            return;
+        }
+
+        // Bind jquery events
+        bindJavaScriptEvents(widget.getElement());
+
+        // When we attach it, configure the tooltip
+        widget.addAttachHandler(new AttachEvent.Handler() {
+
+            @Override
+            public void onAttachOrDetach(final AttachEvent event) {
+                init();
+            }
+        });
+    }
+
+    /**
+     * Force show the Tooltip
+     */
+    public void show() {
+        call(SHOW);
+    }
+
+    /**
+     * Toggle the Tooltip to either show/hide
+     */
+    public void toggle() {
+        call(TOGGLE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return asWidget().toString();
+    }
+
+    private native void updateBool(Element e, String option, boolean value) /*-{
+        var dataTarget = this.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::dataTarget;
+        $wnd.jQuery(e).data(dataTarget).options[option] = value;
+    }-*/;
+
+    private native void updateDelay(Element e, int showDelay, int hideDealy) /*-{
+        var dataTarget = this.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::dataTarget;
+        $wnd.jQuery(e).data(dataTarget).options['delay'] = {
+            show : showDelay,
+            hide : hideDelay
+        };
+    }-*/;
+
+    private native void updateString(Element e, String option, String value) /*-{
+        var dataTarget = this.@org.gwtbootstrap3.client.ui.base.AbstractTooltip::dataTarget;
+        $wnd.jQuery(e).data(dataTarget).options[option] = value;
+    }-*/;
+
+    /**
+     * Update the title. This should only be called when the title is already showing. It causes a small flicker but
+     * updates the title immediately.
+     */
+    protected abstract void updateTitleWhenShowing();
+
+}


### PR DESCRIPTION
Refactored tooltip and popover to use common code found in AbstractTooltip.  Changes to the tooltip/popover are now immediate without the need to call reconfigure.  

The reconfigure method is now depreciated and will be removed after the next release.