### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#GwtBootstrap3 [![Build Status](https://travis-ci.org/gwtbootstrap3/gwtbootstrap3.svg?branch=master)](https://travis-ci.org/gwtbootstrap3/gwtbootstrap3) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.gwtbootstrap3/gwtbootstrap3/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/org.gwtbootstrap3/gwtbootstrap3/)
+# GwtBootstrap3 [![Build Status](https://travis-ci.org/gwtbootstrap3/gwtbootstrap3.svg?branch=master)](https://travis-ci.org/gwtbootstrap3/gwtbootstrap3) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.gwtbootstrap3/gwtbootstrap3/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/org.gwtbootstrap3/gwtbootstrap3/)
 
 GWTBootstrap3 is a wrapper for [Twitter Bootstrap](http://getbootstrap.com/), which helps you develop responsive, mobile first HTML, CSS, and JS projects on the web using Java and Google Web Toolkit (GWT). 
 
-###Add GWTBootstrap3 to your project
+### Add GWTBootstrap3 to your project
 You can easily add GWTBootstrap3 to your project by including the library as a Maven dependency.
 ```xml
 <dependency>
@@ -12,19 +12,19 @@ You can easily add GWTBootstrap3 to your project by including the library as a M
     <scope>provided</scope>
 </dependency>
 ```
-###Current Release
+### Current Release
 * 0.9.4 - Released on 21 February 2017. 
   * Based on Bootstrap v3.3.7
 * [Demo](http://gwtbootstrap3.github.io/gwtbootstrap3-demo/) - The GWTBootstrap3 0.9.4 Demo.
 * [API Docs](http://gwtbootstrap3.github.io/gwtbootstrap3-demo/apidocs) - The GWTBootstrap3 0.9.4 API Javadoc.
 * [Supported Features](https://github.com/gwtbootstrap3/gwtbootstrap3/wiki/Supported-Features) - Current releases supported features.
 
-###Current Snapshot
+### Current Snapshot
 * 1.0-SNAPSHOT
 * [Snapshot Demo](http://gwtbootstrap3.github.io/gwtbootstrap3-demo/snapshot) - GWTBootstrap3 v1.0-SNAPSHOT Demo. (Updated after every commit)
 * [API Docs](http://gwtbootstrap3.github.io/gwtbootstrap3-demo/snapshot/apidocs) - GWTBootstrap3 v1.0-SNAPSHOT Javadoc. (Updated after every commit)
 
-###Resources
+### Resources
 * [Project Wiki](https://github.com/gwtbootstrap3/gwtbootstrap3/wiki) - Help with getting started and other useful project help.
 * [GwtBootstrap3 Google Group](https://groups.google.com/forum/?fromgroups#!forum/gwtbootstrap3) - Ask questions here.
 * [Issues](https://github.com/gwtbootstrap3/gwtbootstrap3/issues) - File bugs here.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
