### PR TITLE
Fixing issue with HTML not getting set correctly as the inner HTML of…

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
@@ -43,6 +43,7 @@ public class Paragraph extends HTMLPanel implements HasAlignment, HasEmphasis {
 
     public Paragraph(final String html) {
         super(ParagraphElement.TAG, html);
+        setHTML(html);
     }
 
     public void setText(final String text) {

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/html/Paragraph.java
@@ -4,7 +4,7 @@ package org.gwtbootstrap3.client.ui.html;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 GwtBootstrap3
+ * Copyright (C) 2017 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Noticed that the following type of syntax in a UiBinder XML file wasn't working in my project, and tracked the issue down to a problem in the constructor for the "Paragraph" tag.  Would you consider merging this fix back into the main repository?

Example which failed to render without this fix:

<h:Paragraph><ul><li>Hello World</li></ul></h:Paragraph>