### PR TITLE
Fix leak in Breadcrumbs widget

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Breadcrumbs.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Breadcrumbs.java
@@ -24,14 +24,11 @@ import org.gwtbootstrap3.client.ui.constants.Styles;
 import org.gwtbootstrap3.client.ui.html.OrderedList;
 
 import com.google.gwt.user.client.ui.Widget;
-import com.google.gwt.user.client.ui.WidgetCollection;
 
 /**
  * @author Joshua Godi
  */
 public class Breadcrumbs extends OrderedList {
-    private final WidgetCollection children = new WidgetCollection(this);
-
     public Breadcrumbs() {
         setStyleName(Styles.BREADCRUMB);
     }
@@ -46,8 +43,8 @@ public class Breadcrumbs extends OrderedList {
 
     @Override
     protected void onAttach() {
-        if (!isOrWasAttached() && children.size() > 0) {
-            final Widget lastWidget = children.get(children.size() - 1);
+        if (!isOrWasAttached() && getChildren().size() > 0) {
+            final Widget lastWidget = getChildren().get(getChildren().size() - 1);
             lastWidget.addStyleName(Styles.ACTIVE);
         }
 
@@ -61,6 +58,5 @@ public class Breadcrumbs extends OrderedList {
     public void add(final Widget w) {
         w.addStyleName(Styles.ACTIVE);
         super.add(w);
-        children.add(w);
     }
 }


### PR DESCRIPTION
Hi, I'm a maintainer of [oVirt/RHV admin UI](https://gerrit.ovirt.org/#/q/project:ovirt-engine) project, which is based on GWT and [GWTP](https://github.com/ArcBees/GWTP) framework.

We found a leak in the [Breadcrumbs](https://github.com/gwtbootstrap3/gwtbootstrap3/blob/master/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Breadcrumbs.java) widget, so I thought I'd post a bugfix PR. The problem is that the `WidgetCollection children` isn't properly cleaned up, while also duplicating the `children` state inherited from `ComplexPanel` base widget.

Code snippet that exposes the leak:
```
Breadcrumbs b = new Breadcrumbs();
b.add(new Label("foo"));
b.clear();
b.add(new Label("bar")); // Breadcrumbs#children size is 2
```

I verified this fix on a local oVirt WebAdmin master build.

Currently, we work around this issue by re-assigning the `Breadcrumbs` variable itself, [see this patch](https://gerrit.ovirt.org/#/c/85218/) for details.

(I'm also wondering why the `Breadcrumbs` widget had its own `children` to begin with, but didn't find much clues from looking at the git log.)