### PR TITLE
Migrate JSNI code to JSInterop

### DIFF
--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3ClientBundle.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3ClientBundle.java
@@ -31,6 +31,9 @@ public interface GwtBootstrap3ClientBundle extends ClientBundle {
 
     static final GwtBootstrap3ClientBundle INSTANCE = GWT.create(GwtBootstrap3ClientBundle.class);
 
+    @Source("resource/js/gwtbootstrap3.js")
+    TextResource gwtBootstrap3();
+
     @Source("resource/js/jquery-1.12.4.min.cache.js")
     TextResource jQuery();
 

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3EntryPoint.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/GwtBootstrap3EntryPoint.java
@@ -23,6 +23,8 @@ package org.gwtbootstrap3.client;
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.ScriptInjector;
 
+import jsinterop.annotations.JsMethod;
+
 /**
  * Provides script injection for jQuery and boostrap if they aren't already loaded.
  * 
@@ -32,26 +34,27 @@ import com.google.gwt.core.client.ScriptInjector;
 public class GwtBootstrap3EntryPoint implements EntryPoint {
 
     /**
-     * Check to see if Boostrap is loaded already.
+     * Check to see if Bootstrap is loaded already.
      * 
-     * @return true is Boostreap loaded, false otherwise.
+     * @return true is Bootstrap loaded, false otherwise.
      */
-    private native boolean isBootstrapLoaded() /*-{
-        return typeof $wnd['jQuery'].fn.emulateTransitionEnd !== 'undefined'
-    }-*/;
+    @JsMethod
+    private static native boolean isBootstrapLoaded();
 
     /**
      * Check to see if jQuery is loaded already
      *
      * @return true is jQuery is loaded, false otherwise
      */
-    private native boolean isjQueryLoaded() /*-{
-        return (typeof $wnd['jQuery'] !== 'undefined');
-    }-*/;
+    @JsMethod
+    private static native boolean isjQueryLoaded();
 
     /** {@inheritDoc} */
     @Override
     public void onModuleLoad() {
+        ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.gwtBootstrap3().getText())
+                .setWindow(ScriptInjector.TOP_WINDOW)
+                .inject();
         if (!isjQueryLoaded()) {
             ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.jQuery().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/js/EventHandler.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/js/EventHandler.java
@@ -1,0 +1,39 @@
+package org.gwtbootstrap3.client.shared.js;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2018 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.user.client.Event;
+
+import jsinterop.annotations.JsFunction;
+
+/**
+ * EventHandler helper functional interface to trigger
+ * Java event functions inside JavaScript
+ * @author Thiago Ricciardi
+ *
+ */
+@JsFunction
+@FunctionalInterface
+public interface EventHandler {
+
+    void callEventHandler(Event event);
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/js/JQuery.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/shared/js/JQuery.java
@@ -1,0 +1,155 @@
+package org.gwtbootstrap3.client.shared.js;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2018 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.dom.client.Element;
+
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+/**
+ * jQuery and Bootstrap methods wrapper
+ * @author Thiago Ricciardi
+ *
+ */
+@JsType(isNative=true, namespace=JsPackage.GLOBAL, name="jQuery")
+public class JQuery {
+
+    /**
+     * Create a JQuery object
+     * @param element the element to jQuerify 
+     * @return JQuery object of element
+     */
+    @JsMethod(namespace=JsPackage.GLOBAL, name="jQuery")
+    public static native JQuery jQuery(Element element);
+    /**
+     * Select jQuery elements and create a JQuery object
+     * @param selector jQuery selector
+     * @return JQuery object of elements selected
+     */
+    @JsMethod(namespace=JsPackage.GLOBAL, name="jQuery")
+    public static native JQuery jQuery(String selector);
+
+    /**
+     * Bootstrap button() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery button(String method);
+
+    /**
+     * jQuery html() method
+     * @param htmlString A string of HTML to set as the content of each matched element
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery html(String htmlString);
+
+    /**
+     * jQuery on() method
+     * @param events One or more space-separated event types and optional namespaces,
+     * such as "click" or "keydown.myPlugin"
+     * @param function A function to execute when the event is triggered
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery on(String events, EventHandler function);
+
+    /**
+     * jQuery off() method
+     * @param events One or more space-separated event types and optional namespaces,
+     * or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin"
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery off(String events);
+
+    /**
+     * Bootstrap alert() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery alert(String method);
+
+    /**
+     * Bootstrap carousel() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery carousel(String method);
+    /**
+     * Bootstrap carousel() method
+     * @param slideNumber particular frame (0 based, similar to an array)
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery carousel(int slideNumber);
+
+    /**
+     * Bootstrap collapse() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery collapse(String method);
+
+    /**
+     * Bootstrap modal() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery modal(String method);
+
+    /**
+     * Bootstrap popover() method
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery popover();
+    /**
+     * Bootstrap popover() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery popover(String method);
+
+    /**
+     * Bootstrap scrollspy() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery scrollspy(String method);
+
+    /**
+     * Bootstrap tab() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery tab(String method);
+
+    /**
+     * Bootstrap tooltip() method
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery tooltip();
+    /**
+     * Bootstrap tooltip() method
+     * @param method the method string
+     * @return JQuery object for chaining purposes
+     */
+    public native JQuery tooltip(String method);
+
+}

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Affix.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Affix.java
@@ -23,6 +23,8 @@ package org.gwtbootstrap3.client.ui;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.UIObject;
 
+import jsinterop.annotations.JsMethod;
+
 /**
  * An Affix is an element/container that gets "pinned" as soon as a certain
  * amount of pixels have been scrolled.
@@ -78,9 +80,6 @@ public class Affix {
 
     // @formatter:off
 
-    private static native void internalAffix(final Element e, final int offset) /*-{
-        $wnd.jQuery(e).affix({
-            offset: offset
-        });
-    }-*/;
+    @JsMethod
+    private static native void internalAffix(final Element e, final int offset);
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Alert.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Alert.java
@@ -24,6 +24,7 @@ import org.gwtbootstrap3.client.shared.event.AlertCloseEvent;
 import org.gwtbootstrap3.client.shared.event.AlertCloseHandler;
 import org.gwtbootstrap3.client.shared.event.AlertClosedEvent;
 import org.gwtbootstrap3.client.shared.event.AlertClosedHandler;
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.HasResponsiveness;
 import org.gwtbootstrap3.client.ui.base.HasType;
 import org.gwtbootstrap3.client.ui.base.button.CloseButton;
@@ -239,25 +240,24 @@ public class Alert extends Div implements HasWidgets, HasText, HasType<AlertType
     }
 
     // @formatter:off
-    private native void alert(final Element e, final String arg) /*-{
-        $wnd.jQuery(e).alert(arg);
-    }-*/;
+    private void alert(final Element e, final String arg) {
+        JQuery.jQuery(e).alert(arg);
+    }
 
-    private native void bindJavaScriptEvents(final Element e) /*-{
-        var target = this;
-        var $alert = $wnd.jQuery(e);
+    private void bindJavaScriptEvents(final Element e) {
+        JQuery alert = JQuery.jQuery(e);
 
-        $alert.on('close.bs.alert', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Alert::onClose(Lcom/google/gwt/user/client/Event;)(evt);
+        alert.on("close.bs.alert", (evt) -> {
+            onClose(evt);
         });
 
-        $alert.on('closed.bs.alert', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Alert::onClosed(Lcom/google/gwt/user/client/Event;)(evt);
+        alert.on("closed.bs.alert", (evt) -> {
+            onClosed(evt);
         });
-    }-*/;
+    }
 
-    private native void unbindJavaScriptEvents(final Element e) /*-{
-        $wnd.jQuery(e).off('close.bs.alert');
-        $wnd.jQuery(e).off('closed.bs.alert');
-    }-*/;
+    private void unbindJavaScriptEvents(final Element e) {
+        JQuery.jQuery(e).off("close.bs.alert");
+        JQuery.jQuery(e).off("closed.bs.alert");
+    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Carousel.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Carousel.java
@@ -24,12 +24,15 @@ import org.gwtbootstrap3.client.shared.event.CarouselSlidEvent;
 import org.gwtbootstrap3.client.shared.event.CarouselSlidHandler;
 import org.gwtbootstrap3.client.shared.event.CarouselSlideEvent;
 import org.gwtbootstrap3.client.shared.event.CarouselSlideHandler;
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.constants.Attributes;
 import org.gwtbootstrap3.client.ui.constants.Styles;
 import org.gwtbootstrap3.client.ui.html.Div;
 
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Event;
+
+import jsinterop.annotations.JsMethod;
 
 /**
  * @author Joshua Godi
@@ -148,38 +151,32 @@ public class Carousel extends Div {
         fireEvent(new CarouselSlidEvent(this, evt));
     }
 
-    private native void bindJavaScriptEvents(final com.google.gwt.dom.client.Element e) /*-{
-        var target = this;
-        var $carousel = $wnd.jQuery(e);
+    private void bindJavaScriptEvents(final com.google.gwt.dom.client.Element e) {
+        JQuery carousel = JQuery.jQuery(e);
 
-        $carousel.on('slide.bs.carousel', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Carousel::onSlide(Lcom/google/gwt/user/client/Event;)(evt);
+        carousel.on("slide.bs.carousel", (evt) -> {
+            onSlide(evt);
         });
 
-        $carousel.on('slid.bs.carousel', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Carousel::onSlid(Lcom/google/gwt/user/client/Event;)(evt);
+        carousel.on("slid.bs.carousel", (evt) -> {
+            onSlid(evt);
         });
-    }-*/;
+    }
 
-    private native void unbindJavaScriptEvents(final com.google.gwt.dom.client.Element e) /*-{
-        $wnd.jQuery(e).off('slide.bs.carousel');
-        $wnd.jQuery(e).off('slid.bs.carousel');
-    }-*/;
+    private void unbindJavaScriptEvents(final com.google.gwt.dom.client.Element e) {
+        JQuery.jQuery(e).off("slide.bs.carousel");
+        JQuery.jQuery(e).off("slid.bs.carousel");
+    }
 
-    private native void carousel(final com.google.gwt.dom.client.Element e, final int interval, final String pause,
-                                 final boolean wrap) /*-{
-        $wnd.jQuery(e).carousel({
-            interval: interval,
-            pause: pause,
-            wrap: wrap
-        });
-    }-*/;
+    @JsMethod
+    private static native void carousel(final com.google.gwt.dom.client.Element e, final int interval, final String pause,
+                                 final boolean wrap);
 
-    private native void fireMethod(final com.google.gwt.dom.client.Element e, String method) /*-{
-        $wnd.jQuery(e).carousel(method);
-    }-*/;
+    private void fireMethod(final com.google.gwt.dom.client.Element e, String method) {
+        JQuery.jQuery(e).carousel(method);
+    }
 
-    private native void fireMethod(final com.google.gwt.dom.client.Element e, int slideNumber) /*-{
-        $wnd.jQuery(e).carousel(slideNumber);
-    }-*/;
+    private void fireMethod(final com.google.gwt.dom.client.Element e, int slideNumber) {
+        JQuery.jQuery(e).carousel(slideNumber);
+    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Collapse.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Collapse.java
@@ -32,6 +32,7 @@ import org.gwtbootstrap3.client.shared.event.ShowEvent;
 import org.gwtbootstrap3.client.shared.event.ShowHandler;
 import org.gwtbootstrap3.client.shared.event.ShownEvent;
 import org.gwtbootstrap3.client.shared.event.ShownHandler;
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
 import org.gwtbootstrap3.client.ui.constants.CollapseParam;
 import org.gwtbootstrap3.client.ui.constants.Styles;
@@ -170,35 +171,34 @@ public class Collapse extends Div {
         fireEvent(new HiddenEvent(evt));
     }
 
-    private native void bindJavaScriptEvents(final com.google.gwt.dom.client.Element e) /*-{
-        var target = this;
-        var $collapse = $wnd.jQuery(e);
+    private void bindJavaScriptEvents(final com.google.gwt.dom.client.Element e) {
+        JQuery collapse = JQuery.jQuery(e);
 
-        $collapse.on('show.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Collapse::onShow(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("show.bs.collapse", (evt) -> {
+            onShow(evt);
         });
 
-        $collapse.on('shown.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Collapse::onShown(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("shown.bs.collapse", (evt) -> {
+            onShown(evt);
         });
 
-        $collapse.on('hide.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Collapse::onHide(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("hide.bs.collapse", (evt) -> {
+            onHide(evt);
         });
 
-        $collapse.on('hidden.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Collapse::onHidden(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("hidden.bs.collapse", (evt) -> {
+            onHidden(evt);
         });
-    }-*/;
+    }
 
-    private native void unbindJavaScriptEvents(final Element e) /*-{
-        $wnd.jQuery(e).off('show.bs.collapse');
-        $wnd.jQuery(e).off('shown.bs.collapse');
-        $wnd.jQuery(e).off('hide.bs.collapse');
-        $wnd.jQuery(e).off('hidden.bs.collapse');
-    }-*/;
+    private void unbindJavaScriptEvents(final Element e) {
+        JQuery.jQuery(e).off("show.bs.collapse");
+        JQuery.jQuery(e).off("shown.bs.collapse");
+        JQuery.jQuery(e).off("hide.bs.collapse");
+        JQuery.jQuery(e).off("hidden.bs.collapse");
+    }
 
-    private native void fireMethod(final Element e, String method) /*-{
-        $wnd.jQuery(e).collapse(method);
-    }-*/;
+    private void fireMethod(final Element e, String method) {
+        JQuery.jQuery(e).collapse(method);
+    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Modal.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Modal.java
@@ -28,6 +28,7 @@ import org.gwtbootstrap3.client.shared.event.ModalShowEvent;
 import org.gwtbootstrap3.client.shared.event.ModalShowHandler;
 import org.gwtbootstrap3.client.shared.event.ModalShownEvent;
 import org.gwtbootstrap3.client.shared.event.ModalShownHandler;
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
 import org.gwtbootstrap3.client.ui.base.modal.ModalContent;
 import org.gwtbootstrap3.client.ui.base.modal.ModalDialog;
@@ -312,42 +313,41 @@ public class Modal extends Div implements IsClosable {
         }
     }
 
-    private native void bindJavaScriptEvents(final Element e) /*-{
-        var target = this;
-        var $modal = $wnd.jQuery(e);
+    private void bindJavaScriptEvents(final Element e) {
+        JQuery modal = JQuery.jQuery(e);
 
-        $modal.on('show.bs.modal', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Modal::onShow(Lcom/google/gwt/user/client/Event;)(evt);
+        modal.on("show.bs.modal", (evt) -> {
+            onShow(evt);
         });
 
-        $modal.on('shown.bs.modal', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Modal::onShown(Lcom/google/gwt/user/client/Event;)(evt);
+        modal.on("shown.bs.modal", (evt) -> {
+            onShown(evt);
         });
 
-        $modal.on('hide.bs.modal', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Modal::onHide(Lcom/google/gwt/user/client/Event;)(evt);
+        modal.on("hide.bs.modal", (evt) -> {
+            onHide(evt);
         });
 
-        $modal.on('hidden.bs.modal', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.Modal::onHidden(Lcom/google/gwt/user/client/Event;)(evt);
+        modal.on("hidden.bs.modal", (evt) -> {
+            onHidden(evt);
         });
-    }-*/;
+    }
 
-    private native void modal(final Element e, final String arg) /*-{
-        $wnd.jQuery(e).modal(arg);
-    }-*/;
+    private void modal(final Element e, final String arg) {
+        JQuery.jQuery(e).modal(arg);
+    }
 
     // Will iterate over all the modals, if they are visible it will hide them
-    private native void hideOtherModals() /*-{
-        $wnd.jQuery('.modal.in').modal('hide');
-    }-*/;
+    private void hideOtherModals() {
+        JQuery.jQuery(".modal.in").modal("hide");
+    }
 
     // Unbinds all the handlers
-    private native void unbindAllHandlers(final Element e) /*-{
-        var $e = $wnd.jQuery(e);
-        $e.off('show.bs.modal');
-        $e.off('shown.bs.modal');
-        $e.off('hide.bs.modal');
-        $e.off('hidden.bs.modal');
-    }-*/;
+    private void unbindAllHandlers(final Element e) {
+        JQuery je = JQuery.jQuery(e);
+        je.off("show.bs.modal");
+        je.off("shown.bs.modal");
+        je.off("hide.bs.modal");
+        je.off("hidden.bs.modal");
+    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/NavbarCollapse.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/NavbarCollapse.java
@@ -32,6 +32,7 @@ import org.gwtbootstrap3.client.shared.event.ShowEvent;
 import org.gwtbootstrap3.client.shared.event.ShowHandler;
 import org.gwtbootstrap3.client.shared.event.ShownEvent;
 import org.gwtbootstrap3.client.shared.event.ShownHandler;
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.helper.StyleHelper;
 import org.gwtbootstrap3.client.ui.constants.CollapseParam;
 import org.gwtbootstrap3.client.ui.constants.Styles;
@@ -165,35 +166,34 @@ public class NavbarCollapse extends FlowPanel {
         fireEvent(new HiddenEvent(evt));
     }
 
-    private native void bindJavaScriptEvents(final com.google.gwt.dom.client.Element e) /*-{
-        var target = this;
-        var $collapse = $wnd.jQuery(e);
+    private void bindJavaScriptEvents(final com.google.gwt.dom.client.Element e) {
+        JQuery collapse = JQuery.jQuery(e);
 
-        $collapse.on('show.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.NavbarCollapse::onShow(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("show.bs.collapse", (evt) -> {
+            onShow(evt);
         });
 
-        $collapse.on('shown.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.NavbarCollapse::onShown(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("shown.bs.collapse", (evt) -> {
+            onShown(evt);
         });
 
-        $collapse.on('hide.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.NavbarCollapse::onHide(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("hide.bs.collapse", (evt) -> {
+            onHide(evt);
         });
 
-        $collapse.on('hidden.bs.collapse', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.NavbarCollapse::onHidden(Lcom/google/gwt/user/client/Event;)(evt);
+        collapse.on("hidden.bs.collapse", (evt) -> {
+            onHidden(evt);
         });
-    }-*/;
+    }
 
-    private native void unbindJavaScriptEvents(final com.google.gwt.dom.client.Element e) /*-{
-        $wnd.jQuery(e).off('show.bs.collapse');
-        $wnd.jQuery(e).off('shown.bs.collapse');
-        $wnd.jQuery(e).off('hide.bs.collapse');
-        $wnd.jQuery(e).off('hidden.bs.collapse');
-    }-*/;
+    private void unbindJavaScriptEvents(final com.google.gwt.dom.client.Element e) {
+        JQuery.jQuery(e).off("show.bs.collapse");
+        JQuery.jQuery(e).off("shown.bs.collapse");
+        JQuery.jQuery(e).off("hide.bs.collapse");
+        JQuery.jQuery(e).off("hidden.bs.collapse");
+    }
 
-    private native void fireMethod(final Element e, final String command) /*-{
-        $wnd.jQuery(e).collapse(command);
-    }-*/;
+    private void fireMethod(final Element e, final String command) {
+        JQuery.jQuery(e).collapse(command);
+    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Popover.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Popover.java
@@ -20,9 +20,9 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.AbstractTooltip;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -111,9 +111,9 @@ public class Popover extends AbstractTooltip {
      * @param e the {@link Element}.
      * @param arg the arg
      */
-    private native void call(final Element e, final String arg) /*-{
-        $wnd.jQuery(e).popover(arg);
-    }-*/;
+    private void call(final Element e, final String arg) {
+        JQuery.jQuery(e).popover(arg);
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -132,10 +132,10 @@ public class Popover extends AbstractTooltip {
     @Override
     public void init() {
         Element element = getWidget().getElement();
-        JavaScriptObject baseOptions = createOptions(element, isAnimated(), isHtml(), getSelector(),
+        createOptions(element, isAnimated(), isHtml(), getSelector(),
                 getTrigger().getCssName(), getShowDelayMs(), getHideDelayMs(), getContainer(), prepareTemplate(), 
                 getViewportSelector(), getViewportPadding());
-        popover(element, baseOptions, getContent());
+        popover(element, getContent());
         bindJavaScriptEvents(element);
         setInitialized(true);
     }
@@ -143,19 +143,19 @@ public class Popover extends AbstractTooltip {
     /**
      * Create the popover.
      */
-    private native void popover(Element e, JavaScriptObject options, String content) /*-{
-        var target = this;
-        options['content'] = function(){
-            return target.@org.gwtbootstrap3.client.ui.Popover::getContent()();
-        };
-        $wnd.jQuery(e).popover(options);
-    }-*/;
+    private void popover(Element e, String content) {
+        e.setAttribute("data-content", content);
+        JQuery.jQuery(e).popover();
+    }
 
     /**
      * @param content the content of the popover to set
      */
     public void setContent(String content) {
         this.content = content;
+        if (initialized) {
+            updateString(widget.getElement(), "content", content);
+        }
     }
 
     /** {@inheritDoc} */
@@ -170,8 +170,8 @@ public class Popover extends AbstractTooltip {
      *
      * @param e the popover {@link Element}.
      */
-    private native void updateTitleWhenShowing(Element e) /*-{
-        $wnd.jQuery(e).popover('fixTitle').popover('show');
-    }-*/;
+    private void updateTitleWhenShowing(Element e) {
+        JQuery.jQuery(e).popover("fixTitle").popover("show");
+    };
 
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/ScrollSpy.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/ScrollSpy.java
@@ -20,11 +20,14 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.HasId;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.UIObject;
+
+import jsinterop.annotations.JsMethod;
 
 /**
  * A ScrollSpy handles scrolling events (typically on {@code <body>}) and
@@ -136,15 +139,10 @@ public class ScrollSpy {
         refresh(spyOn);
     }
 
-    private native void init(final Element e, final String target) /*-{
-        var $e = $wnd.jQuery(e);
+    @JsMethod
+    private static native void init(final Element e, final String target);
 
-        $e.scrollspy({
-            target: target
-        });
-    }-*/;
-
-    private native void refresh(final Element e) /*-{
-        $wnd.jQuery(e).scrollspy('refresh');
-    }-*/;
+    private void refresh(final Element e) {
+        JQuery.jQuery(e).scrollspy("refresh");
+    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/TabListItem.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/TabListItem.java
@@ -28,6 +28,7 @@ import org.gwtbootstrap3.client.shared.event.TabShowEvent;
 import org.gwtbootstrap3.client.shared.event.TabShowHandler;
 import org.gwtbootstrap3.client.shared.event.TabShownEvent;
 import org.gwtbootstrap3.client.shared.event.TabShownHandler;
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.HasDataTarget;
 import org.gwtbootstrap3.client.ui.constants.IconSize;
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -229,27 +230,26 @@ public class TabListItem extends AnchorListItem implements HasDataTarget {
         fireEvent(new TabShownEvent(this, evt));
     }
 
-    private native void showTab(Element e) /*-{
-        $wnd.jQuery(e).tab('show');
-    }-*/;
+    private void showTab(Element e) {
+        JQuery.jQuery(e).tab("show");
+    }
 
     // @formatter:off
-    private native void bindJavaScriptEvents(final Element e) /*-{
-        var target = this;
-        var $tab = $wnd.jQuery(e);
+    private void bindJavaScriptEvents(final Element e) {
+        JQuery tab = JQuery.jQuery(e);
 
-        $tab.on('show.bs.tab', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.TabListItem::onShow(Lcom/google/gwt/user/client/Event;)(evt);
+        tab.on("show.bs.tab", (evt) -> {
+            onShow(evt);
         });
 
-        $tab.on('shown.bs.tab', function (evt) {
-            target.@org.gwtbootstrap3.client.ui.TabListItem::onShown(Lcom/google/gwt/user/client/Event;)(evt);
+        tab.on("shown.bs.tab", (evt) -> {
+            onShown(evt);
         });
-    }-*/;
+    }
 
-    private native void unbindJavaScriptEvents(final Element e) /*-{
-        $wnd.jQuery(e).off('show.bs.tab');
-        $wnd.jQuery(e).off('shown.bs.tab');
-    }-*/;
+    private void unbindJavaScriptEvents(final Element e) {
+        JQuery.jQuery(e).off("show.bs.tab");
+        JQuery.jQuery(e).off("shown.bs.tab");
+    }
     
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Tooltip.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/Tooltip.java
@@ -20,9 +20,9 @@ package org.gwtbootstrap3.client.ui;
  * #L%
  */
 
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.AbstractTooltip;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -93,9 +93,9 @@ public class Tooltip extends AbstractTooltip {
      * @param e the {@link Element}.
      * @param arg the arg
      */
-    private native void call(final Element e, final String arg) /*-{
-        $wnd.jQuery(e).tooltip(arg);
-    }-*/;
+    private void call(final Element e, final String arg) {
+        JQuery.jQuery(e).tooltip(arg);
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -107,10 +107,10 @@ public class Tooltip extends AbstractTooltip {
     @Override
     public void init() {
         Element element = getWidget().getElement();
-        JavaScriptObject baseOptions = createOptions(element, isAnimated(), isHtml(), getSelector(),
+        createOptions(element, isAnimated(), isHtml(), getSelector(),
                 getTrigger().getCssName(), getShowDelayMs(), getHideDelayMs(), getContainer(), prepareTemplate(), 
                 getViewportSelector(), getViewportPadding());
-        tooltip(element, baseOptions);
+        tooltip(element);
         bindJavaScriptEvents(element);
         setInitialized(true);
     }
@@ -118,9 +118,9 @@ public class Tooltip extends AbstractTooltip {
     /**
      * Create the tooltip.
      */
-    private native void tooltip(Element e, JavaScriptObject options) /*-{
-        $wnd.jQuery(e).tooltip(options);
-    }-*/;
+    private void tooltip(Element e) {
+        JQuery.jQuery(e).tooltip();
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -134,8 +134,8 @@ public class Tooltip extends AbstractTooltip {
      *
      * @param e the tooltip {@link Element}.
      */
-    private native void updateTitleWhenShowing(Element e) /*-{
-        $wnd.jQuery(e).tooltip('fixTitle').tooltip('show');
-    }-*/;
+    private void updateTitleWhenShowing(Element e) {
+        JQuery.jQuery(e).tooltip("fixTitle").tooltip("show");
+    }
 
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/button/AbstractButton.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/button/AbstractButton.java
@@ -22,6 +22,7 @@ package org.gwtbootstrap3.client.ui.base.button;
 
 import java.util.List;
 
+import org.gwtbootstrap3.client.shared.js.JQuery;
 import org.gwtbootstrap3.client.ui.base.ComplexWidget;
 import org.gwtbootstrap3.client.ui.base.HasActive;
 import org.gwtbootstrap3.client.ui.base.HasDataTarget;
@@ -297,7 +298,7 @@ public abstract class AbstractButton extends ComplexWidget implements HasEnabled
 
     // @formatter:off
 
-    private native void button(final Element e, final String arg) /*-{
-        $wnd.jQuery(e).button(arg);
-    }-*/;
+    private void button(final Element e, final String arg) {
+        JQuery.jQuery(e).button(arg);
+    }
 }

--- a/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/HTMLMixin.java
+++ b/gwtbootstrap3/src/main/java/org/gwtbootstrap3/client/ui/base/mixin/HTMLMixin.java
@@ -20,6 +20,8 @@ package org.gwtbootstrap3.client.ui.base.mixin;
  * #L%
  */
 
+import org.gwtbootstrap3.client.shared.js.JQuery;
+
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.UIObject;
 
@@ -45,8 +47,8 @@ public class HTMLMixin<T extends UIObject> extends TextMixin<T> {
         }
     }
 
-    private native void setInnerHTML(Element e, String html) /*-{
-        $wnd.jQuery(e).html(html);
-    }-*/;
+    private void setInnerHTML(Element e, String html) {
+        JQuery.jQuery(e).html(html);
+    }
 
 }

--- a/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/client/resource/js/gwtbootstrap3.js
+++ b/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/client/resource/js/gwtbootstrap3.js
@@ -18,60 +18,67 @@
  * #L%
  */
 
-var org = {
-    gwtbootstrap3: {
-        client: {
-            ui: {
-                base: {
-                    AbstractTooltip: {
-                        updateBool: function(dataTarget, e, option, value) {
-                            window.jQuery(e).data(dataTarget).options[option] = value;
-                        }, // updateBool
-                        updateDelay: function(dataTarget, e, showDelay, hideDelay) {
-                            window.jQuery(e).data(dataTarget).options['delay'] = {
-                                show : showDelay,
-                                hide : hideDelay
-                            };
-                        }, // updateDelay
-                        updateString: function(dataTarget, e, option, value) {
-                            window.jQuery(e).data(dataTarget).options[option] = value;
-                        }, // updateString
-                        updateViewport: function(dataTarget, e, selector, padding) {
-                            window.jQuery(e).data(dataTarget).options['viewport'] = {
-                                selector : selector,
-                                padding : padding
-                            };
-                        } // updateViewport
-                    } // AbstractTooltip
-                }, // base
-                Affix: {
-                    internalAffix: function(e, offset) {
-                        window.jQuery(e).affix({
-                            offset: offset
-                        });
-                    } // internalAffix
-                }, // Affix
-                Carousel: {
-                    carousel: function(e, interval, pause, wrap) {
-                        window.jQuery(e).carousel({
-                            interval: interval,
-                            pause: pause,
-                            wrap: wrap
-                        });
-                    } // carousel
-                }, // Carousel
-                ScrollSpy: {
-                    init: function(e, target) {
-                        window.jQuery(e).scrollspy({
-                            target: target
-                        });
-                    } // init
-                } // ScrollSpy
-            }, // ui
-            GwtBootstrap3EntryPoint: {
-                isBootstrapLoaded: function () { return typeof window['jQuery'].fn.emulateTransitionEnd !== 'undefined'; },
-                isjQueryLoaded: function () { return (typeof window['jQuery'] !== 'undefined'); }
-            } // GwtBootstrap3EntryPoint
-        } // client
-    } // gwtbootstrap3
-} // org;
+function _gwtbootstrap3_Create(parent, name, value) {
+    if (typeof parent[name] === 'undefined') parent[name] = value;
+}
+
+_gwtbootstrap3_Create(this, "org", {});
+_gwtbootstrap3_Create(org, "gwtbootstrap3", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3, "client", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client, "ui", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui, "base", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.base, "AbstractTooltip", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.base.AbstractTooltip, "updateBool",
+function(dataTarget, e, option, value) {
+    window.jQuery(e).data(dataTarget).options[option] = value;
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.base.AbstractTooltip, "updateDelay",
+function(dataTarget, e, showDelay, hideDelay) {
+    window.jQuery(e).data(dataTarget).options['delay'] = {
+        show : showDelay,
+        hide : hideDelay
+    };
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.base.AbstractTooltip, "updateString",
+function(dataTarget, e, option, value) {
+    window.jQuery(e).data(dataTarget).options[option] = value;
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.base.AbstractTooltip, "updateViewport",
+function(dataTarget, e, selector, padding) {
+    window.jQuery(e).data(dataTarget).options['viewport'] = {
+        selector : selector,
+        padding : padding
+    };
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui, "Affix", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.Affix, "internalAffix",
+function(e, offset) {
+    window.jQuery(e).affix({
+        offset: offset
+    });
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui, "Carousel", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.Carousel, "carousel",
+function(e, interval, pause, wrap) {
+    window.jQuery(e).carousel({
+        interval: interval,
+        pause: pause,
+        wrap: wrap
+    });
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui, "ScrollSpy", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.ui.ScrollSpy, "init",
+function(e, target) {
+    window.jQuery(e).scrollspy({
+        target: target
+    });
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client, "GwtBootstrap3EntryPoint", {});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.GwtBootstrap3EntryPoint, "isBootstrapLoaded",
+function () {
+    return typeof window['jQuery'].fn.emulateTransitionEnd !== 'undefined';
+});
+_gwtbootstrap3_Create(org.gwtbootstrap3.client.GwtBootstrap3EntryPoint, "isjQueryLoaded",
+function () {
+    return (typeof window['jQuery'] !== 'undefined');
+});

--- a/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/client/resource/js/gwtbootstrap3.js
+++ b/gwtbootstrap3/src/main/resources/org/gwtbootstrap3/client/resource/js/gwtbootstrap3.js
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+var org = {
+    gwtbootstrap3: {
+        client: {
+            ui: {
+                base: {
+                    AbstractTooltip: {
+                        updateBool: function(dataTarget, e, option, value) {
+                            window.jQuery(e).data(dataTarget).options[option] = value;
+                        }, // updateBool
+                        updateDelay: function(dataTarget, e, showDelay, hideDelay) {
+                            window.jQuery(e).data(dataTarget).options['delay'] = {
+                                show : showDelay,
+                                hide : hideDelay
+                            };
+                        }, // updateDelay
+                        updateString: function(dataTarget, e, option, value) {
+                            window.jQuery(e).data(dataTarget).options[option] = value;
+                        }, // updateString
+                        updateViewport: function(dataTarget, e, selector, padding) {
+                            window.jQuery(e).data(dataTarget).options['viewport'] = {
+                                selector : selector,
+                                padding : padding
+                            };
+                        } // updateViewport
+                    } // AbstractTooltip
+                }, // base
+                Affix: {
+                    internalAffix: function(e, offset) {
+                        window.jQuery(e).affix({
+                            offset: offset
+                        });
+                    } // internalAffix
+                }, // Affix
+                Carousel: {
+                    carousel: function(e, interval, pause, wrap) {
+                        window.jQuery(e).carousel({
+                            interval: interval,
+                            pause: pause,
+                            wrap: wrap
+                        });
+                    } // carousel
+                }, // Carousel
+                ScrollSpy: {
+                    init: function(e, target) {
+                        window.jQuery(e).scrollspy({
+                            target: target
+                        });
+                    } // init
+                } // ScrollSpy
+            }, // ui
+            GwtBootstrap3EntryPoint: {
+                isBootstrapLoaded: function () { return typeof window['jQuery'].fn.emulateTransitionEnd !== 'undefined'; },
+                isjQueryLoaded: function () { return (typeof window['jQuery'] !== 'undefined'); }
+            } // GwtBootstrap3EntryPoint
+        } // client
+    } // gwtbootstrap3
+} // org;

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     </modules>
 
     <properties>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -85,7 +85,7 @@
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.6</nexus-staging-maven-plugin.version>
 
-        <gwt.version>2.7.0</gwt.version>
+        <gwt.version>2.8.0</gwt.version>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -179,6 +179,7 @@
                                 <mode>htmlunit</mode>
                                 <testTimeOut>240</testTimeOut>
                                 <failOnError>true</failOnError>
+                                <generateJsInteropExports>true</generateJsInteropExports>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
**Migrates all JSNI code in gwtboostrap3 to JSInterop maintaining the same functionality.**

This was done because [JSInterop](http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJsInterop.html) is the new standard of JavaScript code interaction with Java, and [JSNI will be removed in GWT 3](http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html).
Also there was a need to upgrade GWT to at least 2.8.0 (due to JSInterop) and Java to 1.8 (due to GWT 2.8.0).

I have tested everything that changed in Chrome Browser v70.0.3538.77 (64-bit) compiling your library in maven and running GWT in SuperDev mode using SDK version 2.8.1.

If you accept this code, I'll make some effort to migrate gwtbootstrap3-extras too.

Please fell free to contact me anytime.
Thanks a lot for sharing gwtbootstrap3!
Thiago Ricciardi